### PR TITLE
Fix custom category creation

### DIFF
--- a/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/CustomCategories/AddCategory/AddCategory.tsx
+++ b/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/CustomCategories/AddCategory/AddCategory.tsx
@@ -20,6 +20,11 @@ interface AddCategoryProps {
   categories: ICategory[];
 }
 
+interface FormValues {
+  name: string;
+  parent: string;
+}
+
 const AddCategory = (props: AddCategoryProps): React.ReactNode => {
   const { request } = React.useContext<any>(AuthContext);
 
@@ -44,7 +49,6 @@ const AddCategory = (props: AddCategoryProps): React.ReactNode => {
     initialValues: { name: "", parent: "" },
     validate: {
       name: isNotEmpty("Name is required"),
-      parent: isNotEmpty("Parent is required"),
     },
   });
 
@@ -52,15 +56,18 @@ const AddCategory = (props: AddCategoryProps): React.ReactNode => {
     (category) => category.parent?.length === 0
   );
 
+  const handleSubmit = (values: FormValues) => {
+    doAddCategory.mutate({
+      value: values.name,
+      parent: values.parent,
+    });
+    form.reset();
+  };
+
   return (
     <Card withBorder shadow="xs">
       <LoadingOverlay visible={doAddCategory.isPending} />
-      <form
-        style={{ width: "100%" }}
-        onSubmit={form.onSubmit((values: { name: string; parent: string }) => {
-          doAddCategory.mutate({ value: values.name, parent: values.parent });
-        })}
-      >
+      <form style={{ width: "100%" }} onSubmit={form.onSubmit(handleSubmit)}>
         <Stack>
           <TextInput
             {...form.getInputProps("name")}

--- a/server/BudgetBoard.Service/Models/TransactionCategoriesConstants.cs
+++ b/server/BudgetBoard.Service/Models/TransactionCategoriesConstants.cs
@@ -1,6 +1,6 @@
 ﻿namespace BudgetBoard.Service.Models;
 
-static class TransactionCategoriesConstants
+public static class TransactionCategoriesConstants
 {
     public static readonly IEnumerable<ICategory> DefaultTransactionCategories = new List<ICategory>([
         new CategoryBase {Value = "Auto & Transport", Parent = ""},

--- a/server/BudgetBoard.Service/TransactionCategoryService.cs
+++ b/server/BudgetBoard.Service/TransactionCategoryService.cs
@@ -35,7 +35,9 @@ public class TransactionCategoryService(ILogger<ITransactionCategoryService> log
             throw new BudgetBoardServiceException("Transaction category cannot have the same name as its parent category.");
         }
 
-        if (!string.IsNullOrEmpty(request.Parent) && !userData.TransactionCategories.Any(c => c.Value.Equals(request.Parent, StringComparison.OrdinalIgnoreCase)))
+        if (!string.IsNullOrEmpty(request.Parent) &&
+            !userData.TransactionCategories.Any(c => c.Value.Equals(request.Parent, StringComparison.OrdinalIgnoreCase)) &&
+            !TransactionCategoriesConstants.DefaultTransactionCategories.Any(c => c.Value.Equals(request.Parent, StringComparison.OrdinalIgnoreCase)))
         {
             _logger.LogError("Attempt to create a transaction category with a parent that does not exist.");
             throw new BudgetBoardServiceException("Parent category does not exist.");

--- a/server/BudgetBoard.Tests/TransactionCategoryServiceTests.cs
+++ b/server/BudgetBoard.Tests/TransactionCategoryServiceTests.cs
@@ -121,6 +121,24 @@ public class TransactionCategoryServiceTests
     }
 
     [Fact]
+    public async Task CreateTransactionCategoryAsync_WhenParentIsDefaultCategory_ShouldNotThrowError()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var transactionCategoryService = new TransactionCategoryService(Mock.Of<ILogger<ITransactionCategoryService>>(), helper.UserDataContext);
+
+        var categoryCreateRequest = _categoryCreateRequestFaker.Generate();
+        categoryCreateRequest.Parent = TransactionCategoriesConstants.DefaultTransactionCategories.Where(tc => tc.Parent.Length == 0).First().Value;
+
+        // Act
+        await transactionCategoryService.CreateTransactionCategoryAsync(helper.demoUser.Id, categoryCreateRequest);
+
+        // Assert
+        helper.UserDataContext.TransactionCategories.Should().HaveCount(1);
+        helper.UserDataContext.TransactionCategories.Single().Parent.Should().Be(categoryCreateRequest.Parent);
+    }
+
+    [Fact]
     public async Task ReadTransactionCategoriesAsync_WhenCalledWithValidData_ShouldReturnCategories()
     {
         // Arrange


### PR DESCRIPTION
Forgot to consider a custom category could be a child of a default category. Now includes default categories in error checking.

Also fixed the form to allow you to leave the parent category empty. This will allow for creating custom parent categories.