### PR TITLE
Fix category list in category select input

### DIFF
--- a/client/src/components/CategorySelect.tsx
+++ b/client/src/components/CategorySelect.tsx
@@ -1,4 +1,5 @@
 import {
+  buildCategoriesTree,
   getFormattedCategoryValue,
   getIsParentCategory,
 } from "~/helpers/category";
@@ -13,7 +14,7 @@ import {
   Text,
   useCombobox,
 } from "@mantine/core";
-import { ICategory } from "~/models/category";
+import { ICategory, ICategoryNode } from "~/models/category";
 import React from "react";
 
 interface CategorySelectProps {
@@ -38,37 +39,62 @@ const CategorySelect = (props: CategorySelectProps): React.ReactNode => {
     },
   });
 
-  const options = props.categories
-    .filter((item) =>
-      item.value.toLowerCase().includes(search.toLowerCase().trim())
-    )
-    .map((category) => (
-      <Combobox.Option
-        key={category.value}
-        value={category.value}
-        active={category.value === props.value}
-      >
-        <Group gap="0.5rem">
-          {areStringsEqual(category.value, props.value) ? (
-            <CheckIcon size={12} />
-          ) : (
-            <div style={{ width: 12 }} />
-          )}
-          <Text
-            fz="sm"
-            style={{
-              fontWeight: getIsParentCategory(category.value, props.categories)
-                ? 700
-                : 400,
-              textWrap: "nowrap",
-            }}
-            pl={getIsParentCategory(category.value, props.categories) ? 0 : 10}
+  const categoriesTree = React.useMemo(
+    () => buildCategoriesTree(props.categories),
+    [props.categories]
+  );
+
+  const buildCategoriesOptions = (categoriesTree: ICategoryNode[]) => {
+    const options: React.ReactNode[] = [];
+    categoriesTree.forEach((category) => {
+      if (category.value.toLowerCase().includes(search.toLowerCase().trim())) {
+        options.push(
+          <Combobox.Option
+            key={category.value}
+            value={category.value}
+            active={category.value === props.value}
           >
-            {category.value}
-          </Text>
-        </Group>
-      </Combobox.Option>
-    ));
+            <Group gap="0.5rem">
+              {areStringsEqual(category.value, props.value) ? (
+                <CheckIcon size={12} />
+              ) : (
+                <div style={{ width: 12 }} />
+              )}
+              <Text
+                fz="sm"
+                style={{
+                  fontWeight: getIsParentCategory(
+                    category.value,
+                    props.categories
+                  )
+                    ? 700
+                    : 400,
+                  textWrap: "nowrap",
+                }}
+                pl={
+                  getIsParentCategory(category.value, props.categories) ? 0 : 10
+                }
+              >
+                {category.value}
+              </Text>
+            </Group>
+          </Combobox.Option>
+        );
+      }
+      if (category?.subCategories.length > 0) {
+        options.push(
+          ...buildCategoriesOptions(
+            category.subCategories.sort((a, b) =>
+              a.value
+                .toLocaleLowerCase()
+                .localeCompare(b.value.toLocaleLowerCase())
+            )
+          )
+        );
+      }
+    });
+    return options;
+  };
 
   return (
     <Combobox
@@ -112,7 +138,7 @@ const CategorySelect = (props: CategorySelectProps): React.ReactNode => {
           size="sm"
         />
         <Combobox.Options mah={300} style={{ overflowY: "auto" }}>
-          {options}
+          {buildCategoriesOptions(categoriesTree)}
         </Combobox.Options>
       </Combobox.Dropdown>
     </Combobox>

--- a/client/src/models/category.ts
+++ b/client/src/models/category.ts
@@ -15,17 +15,17 @@ export interface ICategoryResponse extends ICategory {
 }
 
 export interface ICategoryNode extends ICategory {
-  subCategories: ICategory[];
+  subCategories: ICategoryNode[];
 }
 
 export class CategoryNode implements ICategoryNode {
-  subCategories: ICategory[];
+  subCategories: ICategoryNode[];
   value: string;
   parent: string;
 
   constructor(category?: ICategory) {
-    this.value = category?.value ?? '';
-    this.parent = category?.parent ?? '';
+    this.value = category?.value ?? "";
+    this.parent = category?.parent ?? "";
     this.subCategories = [];
   }
 }


### PR DESCRIPTION
Need to sort the list of categories in the category select input, so that custom categories show up under the right parents.
- Updated the category select options to build a tree of parents and their children
- Created a list of options from this tree that alphabetizes both parents and their respective children