### PR TITLE
Make budget colors consistent with display value

### DIFF
--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetCard/BudgetCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetCard/BudgetCard.tsx
@@ -23,6 +23,7 @@ import { notifications } from "@mantine/notifications";
 import { useField } from "@mantine/form";
 import { Trash2Icon } from "lucide-react";
 import { getBudgetValueColor } from "~/helpers/budgets";
+import { roundAwayFromZero } from "~/helpers/utils";
 
 interface BudgetCardProps {
   budgets: IBudget[];
@@ -87,9 +88,8 @@ const BudgetCard = (props: BudgetCardProps): React.ReactNode => {
     [props.budgets]
   );
 
-  const percentComplete = Math.round(
-    ((props.amount * (props.isIncome ? 1 : -1)) / limit) * 100
-  );
+  const percentComplete =
+    ((props.amount * (props.isIncome ? 1 : -1)) / limit) * 100;
 
   const handleEdit = (newLimit?: number | string) => {
     if (newLimit === "") {
@@ -174,10 +174,16 @@ const BudgetCard = (props: BudgetCardProps): React.ReactNode => {
             <Flex className={classes.numberContainer}>
               <Text
                 className={classes.text}
-                c={getBudgetValueColor(props.amount, limit, props.isIncome)}
+                c={getBudgetValueColor(
+                  roundAwayFromZero(props.amount),
+                  limit,
+                  props.isIncome
+                )}
               >
                 {convertNumberToCurrency(
-                  Math.round(limit - props.amount * (props.isIncome ? 1 : -1)),
+                  roundAwayFromZero(
+                    limit - props.amount * (props.isIncome ? 1 : -1)
+                  ),
                   false
                 )}
               </Text>
@@ -187,7 +193,11 @@ const BudgetCard = (props: BudgetCardProps): React.ReactNode => {
         <Progress.Root size={16} radius="xl">
           <Progress.Section
             value={percentComplete}
-            color={getBudgetValueColor(props.amount, limit, props.isIncome)}
+            color={getBudgetValueColor(
+              roundAwayFromZero(props.amount),
+              limit,
+              props.isIncome
+            )}
           >
             <Progress.Label>{percentComplete.toFixed(0)}%</Progress.Label>
           </Progress.Section>

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetCard/BudgetCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetCard/BudgetCard.tsx
@@ -88,8 +88,9 @@ const BudgetCard = (props: BudgetCardProps): React.ReactNode => {
     [props.budgets]
   );
 
-  const percentComplete =
-    ((props.amount * (props.isIncome ? 1 : -1)) / limit) * 100;
+  const percentComplete = roundAwayFromZero(
+    ((props.amount * (props.isIncome ? 1 : -1)) / limit) * 100
+  );
 
   const handleEdit = (newLimit?: number | string) => {
     if (newLimit === "") {

--- a/client/src/helpers/budgets.ts
+++ b/client/src/helpers/budgets.ts
@@ -140,7 +140,7 @@ export const getBudgetValueColor = (
   amount: number,
   total: number,
   isIncome: boolean
-) => {
+): string => {
   if (isIncome) {
     if (amount < total) {
       return "red";

--- a/client/src/helpers/utils.ts
+++ b/client/src/helpers/utils.ts
@@ -26,3 +26,12 @@ export const getProgress = (amount: number, total: number): number => {
 export const months = [...Array(12).keys()].map((key) =>
   new Date(0, key).toLocaleString("en", { month: "long" })
 );
+
+/**
+ * Rounds a number away from zero. For positive numbers, it behaves like Math.round.
+ * For negative numbers, it rounds away from zero instead of towards zero.
+ *
+ * @param {number} value - The number to round.
+ */
+export const roundAwayFromZero = (value: number): number =>
+  value >= 0 ? Math.round(value) : Math.round(value * -1) * -1;


### PR DESCRIPTION
The display value for budget spending amounts is rounded to the nearest dollar, but the green/red calculation was using the raw value with cents. This caused budgets with a few cents overspent to appear as red even though the UI shows $0 left.

Updated the calculation to round before checking if the budget is overspent.