### PR TITLE
Fix synced accounts to keep source

### DIFF
--- a/server/BudgetBoard.Service/AccountService.cs
+++ b/server/BudgetBoard.Service/AccountService.cs
@@ -45,7 +45,7 @@ public class AccountService(ILogger<IAccountService> logger, UserDataContext use
             Subtype = account.Subtype,
             HideTransactions = account.HideTransactions,
             HideAccount = account.HideAccount,
-            Source = AccountSource.Manual,
+            Source = account.Source ?? AccountSource.Manual,
             UserID = userData.Id
         };
 


### PR DESCRIPTION
Created accounts were by default being set as manual source. They should instead use the passed in value.