### PR TITLE
Remove requirement for unique account names

### DIFF
--- a/server/BudgetBoard.Service/AccountService.cs
+++ b/server/BudgetBoard.Service/AccountService.cs
@@ -16,12 +16,6 @@ public class AccountService(ILogger<IAccountService> logger, UserDataContext use
     {
         var userData = await GetCurrentUserAsync(userGuid.ToString());
 
-        if (userData.Accounts.Any(a => a.Name.Equals(account.Name, StringComparison.OrdinalIgnoreCase)))
-        {
-            _logger.LogError("Attempted to create an account with a duplicate name.");
-            throw new BudgetBoardServiceException("An account with this name already exists!");
-        }
-
         if (!userData.Institutions.Any(i => i.ID == account.InstitutionID))
         {
             _logger.LogError("Attempted to create an account with an invalid institution ID.");

--- a/server/BudgetBoard.Service/AccountService.cs
+++ b/server/BudgetBoard.Service/AccountService.cs
@@ -16,6 +16,12 @@ public class AccountService(ILogger<IAccountService> logger, UserDataContext use
     {
         var userData = await GetCurrentUserAsync(userGuid.ToString());
 
+        if (userData.Accounts.Any(a => account.SyncID != null && a.SyncID == account.SyncID))
+        {
+            _logger.LogError("Attempted to create an account with a duplicate SyncID.");
+            throw new BudgetBoardServiceException("An account with this SyncID already exists.");
+        }
+
         if (!userData.Institutions.Any(i => i.ID == account.InstitutionID))
         {
             _logger.LogError("Attempted to create an account with an invalid institution ID.");

--- a/server/BudgetBoard.Service/SimpleFinService.cs
+++ b/server/BudgetBoard.Service/SimpleFinService.cs
@@ -243,6 +243,7 @@ public class SimpleFinService(
             {
                 foundAccount.InstitutionID = institutionId;
                 foundAccount.Source = AccountSource.SimpleFIN;
+
                 _userDataContext.SaveChanges();
             }
             else

--- a/server/BudgetBoard.Tests/AccountServiceTests.cs
+++ b/server/BudgetBoard.Tests/AccountServiceTests.cs
@@ -75,7 +75,7 @@ public class AccountServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task CreateAccountAsync_DuplicateName_ThrowsError()
+    public async Task CreateAccountAsync_DuplicateName_ShouldStillCreateAccount()
     {
         // Arrange
         var helper = new TestHelper();
@@ -83,27 +83,28 @@ public class AccountServiceTests(ITestOutputHelper testOutputHelper)
 
         var institutionFaker = new InstitutionFaker();
         var institution = institutionFaker.Generate();
-
         institution.UserID = helper.demoUser.Id;
+
         helper.UserDataContext.Institutions.Add(institution);
 
         var accountFaker = new AccountFaker();
-        var firstAccount = accountFaker.Generate();
-        firstAccount.UserID = helper.demoUser.Id;
-        firstAccount.InstitutionID = institution.ID;
-        firstAccount.Name = "Test Account";
-
-        helper.UserDataContext.Accounts.Add(firstAccount);
-
-        var account = _accountCreateRequestFaker.Generate();
+        var account = accountFaker.Generate();
+        account.UserID = helper.demoUser.Id;
         account.InstitutionID = institution.ID;
         account.Name = "Test Account";
 
+        helper.UserDataContext.Accounts.Add(account);
+        helper.UserDataContext.SaveChanges();
+
+        var duplicateAccount = _accountCreateRequestFaker.Generate();
+        duplicateAccount.Name = account.Name;
+        duplicateAccount.InstitutionID = institution.ID;
+
         // Act
-        var createAccountAct = () => accountService.CreateAccountAsync(helper.demoUser.Id, account);
+        await accountService.CreateAccountAsync(helper.demoUser.Id, duplicateAccount);
 
         // Assert
-        await createAccountAct.Should().ThrowAsync<BudgetBoardServiceException>().WithMessage("An account with this name already exists!");
+        helper.demoUser.Accounts.Should().HaveCount(2);
     }
 
     [Fact]

--- a/server/BudgetBoard.Tests/AccountServiceTests.cs
+++ b/server/BudgetBoard.Tests/AccountServiceTests.cs
@@ -108,6 +108,72 @@ public class AccountServiceTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task CreateAccountAsync_WhenDuplicateSyncID_ShouldThrowError()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var accountService = new AccountService(Mock.Of<ILogger<IAccountService>>(), helper.UserDataContext);
+
+        var institutionFaker = new InstitutionFaker();
+        var institution = institutionFaker.Generate();
+        institution.UserID = helper.demoUser.Id;
+
+        helper.UserDataContext.Institutions.Add(institution);
+
+        var accountFaker = new AccountFaker();
+        var account = accountFaker.Generate();
+        account.UserID = helper.demoUser.Id;
+        account.InstitutionID = institution.ID;
+        account.SyncID = "TestSyncID";
+
+        helper.UserDataContext.Accounts.Add(account);
+        helper.UserDataContext.SaveChanges();
+
+        var duplicateAccount = _accountCreateRequestFaker.Generate();
+        duplicateAccount.SyncID = account.SyncID;
+        duplicateAccount.InstitutionID = institution.ID;
+
+        // Act
+        var createAccountAct = () => accountService.CreateAccountAsync(helper.demoUser.Id, duplicateAccount);
+
+        // Assert
+        await createAccountAct.Should().ThrowAsync<BudgetBoardServiceException>().WithMessage("An account with this SyncID already exists.");
+    }
+
+    [Fact]
+    public async Task CreateAccountAsync_WhenSyncIDNull_ShouldNotFlagAsDuplicate()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var accountService = new AccountService(Mock.Of<ILogger<IAccountService>>(), helper.UserDataContext);
+
+        var institutionFaker = new InstitutionFaker();
+        var institution = institutionFaker.Generate();
+        institution.UserID = helper.demoUser.Id;
+
+        helper.UserDataContext.Institutions.Add(institution);
+
+        var accountFaker = new AccountFaker();
+        var account = accountFaker.Generate();
+        account.UserID = helper.demoUser.Id;
+        account.InstitutionID = institution.ID;
+        account.SyncID = null;
+
+        helper.UserDataContext.Accounts.Add(account);
+        helper.UserDataContext.SaveChanges();
+
+        var duplicateAccount = _accountCreateRequestFaker.Generate();
+        duplicateAccount.SyncID = null;
+        duplicateAccount.InstitutionID = institution.ID;
+
+        // Act
+        await accountService.CreateAccountAsync(helper.demoUser.Id, duplicateAccount);
+
+        // Assert
+        helper.demoUser.Accounts.Should().HaveCount(2);
+    }
+
+    [Fact]
     public async Task CreateAccountAsync_NewAccount_HappyPath()
     {
         // Arrange


### PR DESCRIPTION
I originally added this check because having duplicate account names makes things like selecting an account from the drop-down confusing.

The account name isn't used as a key anywhere, so this check is probably overprotective. Instead we should check for a duplicate syncID.
