### PR TITLE
Fix account source bug

### DIFF
--- a/client/src/app/Authorized/PageContent/Dashboard/AccountsCard/AccountsSettings/CreateAccountModal/CreateAccountModal.tsx
+++ b/client/src/app/Authorized/PageContent/Dashboard/AccountsCard/AccountsSettings/CreateAccountModal/CreateAccountModal.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import { AuthContext } from "~/components/AuthProvider/AuthProvider";
 import { translateAxiosError } from "~/helpers/requests";
 import { areStringsEqual } from "~/helpers/utils";
-import { IAccountCreateRequest } from "~/models/account";
+import { AccountSource, IAccountCreateRequest } from "~/models/account";
 import { IInstitution, IInstitutionCreateRequest } from "~/models/institution";
 
 interface CreateAccountModalProps {
@@ -122,6 +122,7 @@ const CreateAccountModal = (props: CreateAccountModalProps) => {
     await doCreateAccount.mutateAsync({
       name: values.name,
       institutionID: institution[0]!.id,
+      source: AccountSource.Manual,
     } as IAccountCreateRequest);
     form.reset();
     props.onClose();

--- a/client/src/models/account.ts
+++ b/client/src/models/account.ts
@@ -13,6 +13,7 @@ export interface IAccountCreateRequest {
   subtype: string;
   hideTransactions: boolean;
   hideAccount: boolean;
+  source: AccountSource;
 }
 
 export interface IAccountUpdateRequest {

--- a/server/BudgetBoard.Service/SimpleFinService.cs
+++ b/server/BudgetBoard.Service/SimpleFinService.cs
@@ -234,6 +234,15 @@ public class SimpleFinService(
 
     private async Task SyncAccountsAsync(ApplicationUser userData, IEnumerable<ISimpleFinAccount> accountsData)
     {
+        // This is a temporary fix for a bug that didn't assign account source for manual accounts.
+        // I will remove this later once we can be sure this won't affect anyone.
+        foreach (var account in userData.Accounts)
+        {
+            if (string.IsNullOrEmpty(account.Source))
+            {
+                account.Source = account.SyncID != null ? AccountSource.SimpleFIN : AccountSource.Manual;
+            }
+        }
         foreach (var accountData in accountsData)
         {
             var institutionId = userData.Institutions.FirstOrDefault(institution => institution.Name == accountData.Org.Name)?.ID;


### PR DESCRIPTION
Creating a new account wasn't applying the correct account source.

Added a check during sync to make sure existing accounts have the right source.