### PR TITLE
Remove manual requirement

### DIFF
--- a/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/CreateTransactionModal/CreateTransactionModal.tsx
+++ b/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/CreateTransactionModal/CreateTransactionModal.tsx
@@ -186,8 +186,6 @@ const CreateTransactionModal = (): React.ReactNode => {
                   form.setFieldValue("accountIds", val)
                 }
                 key={form.key("accountIds")}
-                hideHidden={false}
-                manualOnly
                 maxSelectedValues={1}
               />
             </Stack>

--- a/client/src/components/AccountSelectInput.tsx
+++ b/client/src/components/AccountSelectInput.tsx
@@ -19,7 +19,7 @@ const AccountSelectInput = ({
   selectedAccountIds,
   setSelectedAccountIds,
   hideHidden = false,
-  filterTypes,
+  filterTypes = [],
   manualOnly = false,
   maxSelectedValues = undefined,
   ...props
@@ -51,7 +51,7 @@ const AccountSelectInput = ({
       filteredAccounts = filteredAccounts.filter((a) => !a.hideAccount);
     }
 
-    if (filterTypes && filterTypes.length > 0) {
+    if (filterTypes.length > 0) {
       filteredAccounts = filteredAccounts.filter((a) =>
         filterTypes?.includes(a.type)
       );


### PR DESCRIPTION
Remove the requirement that manual transactions can only be applied to manual accounts. This will break the interest rate predictions, but it was already pretty broken and is going to be replaced soon anyways.