### PR TITLE
Change 2fa required response

### DIFF
--- a/client/src/app/Unauthorized/Login.tsx
+++ b/client/src/app/Unauthorized/Login.tsx
@@ -54,6 +54,13 @@ const Login = (props: LoginProps): React.ReactNode => {
       },
     })
       .then((res: AxiosResponse) => {
+        if (res.data === "RequiresTwoFactor") {
+          props.setLoginCardState(LoginCardState.LoginWith2fa);
+          props.setUserEmail(values.email);
+          props.setUserPassword(values.password);
+          return;
+        }
+
         setAccessToken(res.data.accessToken);
         localStorage.setItem("refresh-token", res.data.refreshToken);
       })
@@ -71,12 +78,6 @@ const Login = (props: LoginProps): React.ReactNode => {
             color: "red",
             message: "Login failed. Check your credentials and try again.",
           });
-        } else if (
-          (error.response?.data as any)?.detail === "RequiresTwoFactor"
-        ) {
-          props.setLoginCardState(LoginCardState.LoginWith2fa);
-          props.setUserEmail(values.email);
-          props.setUserPassword(values.password);
         } else {
           notifications.show({
             color: "red",

--- a/server/BudgetBoard.WebAPI/Overrides/IdentityApiEndpointRouteBuilderExtensions.cs
+++ b/server/BudgetBoard.WebAPI/Overrides/IdentityApiEndpointRouteBuilderExtensions.cs
@@ -113,9 +113,11 @@ public static class IdentityApiEndpointRouteBuilderExtensions
 
         if (!configureOptions.ExcludeLoginPost)
         {
-            routeGroup.MapPost(
+            _ = routeGroup.MapPost(
                 "/login",
-                async Task<Results<Ok<AccessTokenResponse>, EmptyHttpResult, ProblemHttpResult>> (
+                async Task<
+                    Results<Ok<AccessTokenResponse>, Ok<string>, EmptyHttpResult, ProblemHttpResult>
+                > (
                     [FromBody] LoginRequest login,
                     [FromQuery] bool? useCookies,
                     [FromQuery] bool? useSessionCookies,
@@ -152,6 +154,10 @@ public static class IdentityApiEndpointRouteBuilderExtensions
                             result = await signInManager.TwoFactorRecoveryCodeSignInAsync(
                                 login.TwoFactorRecoveryCode
                             );
+                        }
+                        else
+                        {
+                            return TypedResults.Ok(result.ToString());
                         }
                     }
 


### PR DESCRIPTION
Changing the 2fa token required response from a 401 Unauthorized to a 200 OK

This is to work around a bug where certain reverse proxies may interpret the 401 Unauthorized error.