### PR TITLE
Add auto categorization based on regex rule

### DIFF
--- a/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/AutomaticCategorization/AddCategorizationRule/AddCategorizationRule.tsx
+++ b/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/AutomaticCategorization/AddCategorizationRule/AddCategorizationRule.tsx
@@ -1,0 +1,95 @@
+import { Button, Card, TextInput, Stack } from "@mantine/core";
+import { useField } from "@mantine/form";
+import { notifications } from "@mantine/notifications";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import React from "react";
+import { AuthContext } from "~/components/AuthProvider/AuthProvider";
+import CategorySelect from "~/components/CategorySelect";
+import { translateAxiosError } from "~/helpers/requests";
+import { IAutomaticCategorizationRuleRequest } from "~/models/automaticCategorizationRule";
+import { ICategoryResponse } from "~/models/category";
+import { defaultTransactionCategories } from "~/models/transaction";
+
+const AddCategorizationRule = (): React.ReactNode => {
+  const ruleField = useField<string>({
+    initialValue: "",
+    validate: (value) => {
+      try {
+        new RegExp(value);
+        return null;
+      } catch {
+        return "Invalid rule name";
+      }
+    },
+  });
+  const categoryField = useField<string>({
+    initialValue: "",
+  });
+
+  const { request } = React.useContext<any>(AuthContext);
+
+  const transactionCategoriesQuery = useQuery({
+    queryKey: ["transactionCategories"],
+    queryFn: async () => {
+      const res = await request({
+        url: "/api/transactionCategory",
+        method: "GET",
+      });
+
+      if (res.status === 200) {
+        return res.data as ICategoryResponse[];
+      }
+
+      return undefined;
+    },
+  });
+
+  const transactionCategoriesWithCustom = defaultTransactionCategories.concat(
+    transactionCategoriesQuery.data ?? []
+  );
+
+  const queryClient = useQueryClient();
+  const doAddRule = useMutation({
+    mutationFn: async (
+      automaticCategorizationRule: IAutomaticCategorizationRuleRequest
+    ) =>
+      await request({
+        url: "/api/automaticCategorizationRule",
+        method: "POST",
+        data: automaticCategorizationRule,
+      }),
+    onSuccess: async () =>
+      await queryClient.invalidateQueries({
+        queryKey: ["automaticCategorizationRule"],
+      }),
+    onError: (error: AxiosError) => {
+      notifications.show({ message: translateAxiosError(error), color: "red" });
+    },
+  });
+
+  return (
+    <Card withBorder>
+      <Stack gap="0.5rem">
+        <TextInput placeholder="Regex Rule" {...ruleField.getInputProps()} />
+        <CategorySelect
+          categories={transactionCategoriesWithCustom}
+          {...categoryField.getInputProps()}
+          withinPortal
+        />
+        <Button
+          onClick={() => {
+            doAddRule.mutate({
+              categorizationRule: ruleField.getValue(),
+              category: categoryField.getValue(),
+            });
+          }}
+        >
+          Add Rule
+        </Button>
+      </Stack>
+    </Card>
+  );
+};
+
+export default AddCategorizationRule;

--- a/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/AutomaticCategorization/AutomaticCategorization.tsx
+++ b/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/AutomaticCategorization/AutomaticCategorization.tsx
@@ -1,0 +1,49 @@
+import { Stack, Text } from "@mantine/core";
+import AddCategorizationRule from "./AddCategorizationRule/AddCategorizationRule";
+import { AuthContext } from "~/components/AuthProvider/AuthProvider";
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import CategorizationRuleCard from "./CategorizationRuleCard/CategorizationRuleCard";
+import { IAutomaticCategorizationRuleResponse } from "~/models/automaticCategorizationRule";
+
+const AutomaticCategorization = (): React.ReactNode => {
+  const { request } = React.useContext<any>(AuthContext);
+
+  const AutomaticCategorizationQuery = useQuery({
+    queryKey: ["automaticCategorizationRule"],
+    queryFn: async () => {
+      const res = await request({
+        url: "/api/automaticCategorizationRule",
+        method: "GET",
+      });
+
+      if (res.status === 200) {
+        return res.data;
+      }
+
+      return undefined;
+    },
+  });
+
+  return (
+    <Stack gap="0.5rem">
+      <Text c="dimmed" size="sm" fw={600}>
+        Create regex rules to automatically apply a category to your
+        uncategorized transactions during sync.
+      </Text>
+      <AddCategorizationRule />
+      {AutomaticCategorizationQuery.data?.map(
+        (rule: IAutomaticCategorizationRuleResponse) => (
+          <CategorizationRuleCard
+            key={rule.id}
+            id={rule.id}
+            rule={rule.categorizationRule}
+            category={rule.category}
+          />
+        )
+      )}
+    </Stack>
+  );
+};
+
+export default AutomaticCategorization;

--- a/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/AutomaticCategorization/CategorizationRuleCard/CategorizationRuleCard.tsx
+++ b/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/AutomaticCategorization/CategorizationRuleCard/CategorizationRuleCard.tsx
@@ -1,0 +1,67 @@
+import { ActionIcon, Card, Group, Stack, Text } from "@mantine/core";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { TrashIcon } from "lucide-react";
+import React from "react";
+import { AuthContext } from "~/components/AuthProvider/AuthProvider";
+
+interface CategorizationRuleCardProps {
+  id: string;
+  rule: string;
+  category: string;
+}
+
+const CategorizationRuleCard = (props: CategorizationRuleCardProps) => {
+  const { request } = React.useContext<any>(AuthContext);
+
+  const queryClient = useQueryClient();
+  const doDeleteCategorizationRule = useMutation({
+    mutationFn: async (guid: string) => {
+      await request({
+        url: `/api/automaticCategorizationRule`,
+        method: "DELETE",
+        params: { guid },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["automaticCategorizationRule"],
+      });
+    },
+  });
+
+  return (
+    <Card p="0.5rem" radius="md">
+      <Group justify="space-between">
+        <Stack>
+          <Group>
+            <Text c="dimmed" fw={600} size="sm">
+              Rule
+            </Text>
+            <Text fw={600}>{props.rule}</Text>
+          </Group>
+          <Group>
+            <Text c="dimmed" fw={600} size="sm">
+              Category
+            </Text>
+            <Text fw={600}>{props.category}</Text>
+          </Group>
+        </Stack>
+        <Group style={{ alignSelf: "stretch" }}>
+          <ActionIcon
+            color="red"
+            onClick={(e) => {
+              e.stopPropagation();
+              doDeleteCategorizationRule.mutate(props.id);
+            }}
+            h="100%"
+            loading={doDeleteCategorizationRule.isPending}
+          >
+            <TrashIcon size="1rem" />
+          </ActionIcon>
+        </Group>
+      </Group>
+    </Card>
+  );
+};
+
+export default CategorizationRuleCard;

--- a/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/CustomCategories/CustomCategories.tsx
+++ b/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/CustomCategories/CustomCategories.tsx
@@ -32,7 +32,10 @@ const CustomCategories = (): React.ReactNode => {
   );
 
   return (
-    <Stack>
+    <Stack gap="0.5rem">
+      <Text c="dimmed" size="sm" fw={600}>
+        Create custom categories to organize your transactions.
+      </Text>
       <AddCategory categories={transactionCategoriesWithCustom} />
       <Stack>
         <Group px="0.5rem" justify="space-between">

--- a/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/TransactionsSettings.tsx
+++ b/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/TransactionsSettings/TransactionsSettings.tsx
@@ -7,6 +7,7 @@ import { ITransaction } from "~/models/transaction";
 import { AxiosResponse } from "axios";
 import { getDeletedTransactions } from "~/helpers/transactions";
 import DeletedTransactionsCard from "./DeletedTransactionCard/DeletedTransactionsCard";
+import AutomaticCategorization from "./AutomaticCategorization/AutomaticCategorization";
 
 interface TransactionsSettingsProps {
   modalOpened: boolean;
@@ -84,6 +85,19 @@ const TransactionsSettings = (
               </Accordion.Panel>
             </Accordion.Item>
             <Accordion.Item
+              value="automatic categorization"
+              bg="var(--mantine-color-accordion-alternate)"
+            >
+              <Accordion.Control>
+                <Text size="md" fw={600}>
+                  Automatic Categorization
+                </Text>
+              </Accordion.Control>
+              <Accordion.Panel>
+                <AutomaticCategorization />
+              </Accordion.Panel>
+            </Accordion.Item>
+            <Accordion.Item
               value="deleted transactions"
               bg="var(--mantine-color-accordion-alternate)"
             >
@@ -94,6 +108,9 @@ const TransactionsSettings = (
               </Accordion.Control>
               <Accordion.Panel>
                 <Stack gap="0.5rem">
+                  <Text c="dimmed" size="sm" fw={600}>
+                    View and restore deleted transactions.
+                  </Text>
                   {deletedTransactions.length !== 0 ? (
                     deletedTransactions.map(
                       (deletedTransaction: ITransaction) => (

--- a/client/src/models/automaticCategorizationRule.ts
+++ b/client/src/models/automaticCategorizationRule.ts
@@ -1,0 +1,10 @@
+export interface IAutomaticCategorizationRuleRequest {
+  categorizationRule: string;
+  category: string;
+}
+
+export interface IAutomaticCategorizationRuleResponse {
+  id: string;
+  categorizationRule: string;
+  category: string;
+}

--- a/server/BudgetBoard.Database/BudgetBoard.Database.csproj
+++ b/server/BudgetBoard.Database/BudgetBoard.Database.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.8" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>
 

--- a/server/BudgetBoard.Database/Data/UserDataContext.cs
+++ b/server/BudgetBoard.Database/Data/UserDataContext.cs
@@ -5,11 +5,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BudgetBoard.Database.Data
 {
-    public class UserDataContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>
+    public class UserDataContext(DbContextOptions<UserDataContext> options)
+        : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>(options)
     {
-        public UserDataContext(DbContextOptions<UserDataContext> options)
-            : base(options) { }
-
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -79,6 +77,10 @@ namespace BudgetBoard.Database.Data
 
             modelBuilder.Entity<UserSettings>().ToTable("UserSettings");
 
+            modelBuilder
+                .Entity<AutomaticCategorizationRule>()
+                .ToTable("AutomaticCategorizationRule");
+
             modelBuilder.UseIdentityColumns();
         }
 
@@ -91,5 +93,6 @@ namespace BudgetBoard.Database.Data
         public DbSet<Category> TransactionCategories { get; set; }
         public DbSet<Institution> Institutions { get; set; }
         public DbSet<UserSettings> UserSettings { get; set; }
+        public DbSet<AutomaticCategorizationRule> AutomaticCategorizationRules { get; set; }
     }
 }

--- a/server/BudgetBoard.Database/Data/UserDataContext.cs
+++ b/server/BudgetBoard.Database/Data/UserDataContext.cs
@@ -29,6 +29,10 @@ namespace BudgetBoard.Database.Data
                     .HasForeignKey<UserSettings>(e => e.UserID)
                     .IsRequired();
 
+                u.HasMany(e => e.AutomaticCategorizationRules)
+                    .WithOne(e => e.User)
+                    .HasForeignKey(e => e.UserID);
+
                 u.ToTable("User");
             });
 

--- a/server/BudgetBoard.Database/Migrations/20250811015947_AddAutomaticCategorization.Designer.cs
+++ b/server/BudgetBoard.Database/Migrations/20250811015947_AddAutomaticCategorization.Designer.cs
@@ -4,6 +4,7 @@ using BudgetBoard.Database.Data;
 using BudgetBoard.Database.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BudgetBoard.Database.Migrations
 {
     [DbContext(typeof(UserDataContext))]
-    partial class UserDataContextModelSnapshot : ModelSnapshot
+    [Migration("20250811015947_AddAutomaticCategorization")]
+    partial class AddAutomaticCategorization
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/BudgetBoard.Database/Migrations/20250811015947_AddAutomaticCategorization.cs
+++ b/server/BudgetBoard.Database/Migrations/20250811015947_AddAutomaticCategorization.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BudgetBoard.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAutomaticCategorization : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AutomaticCategorizationRule",
+                columns: table => new
+                {
+                    ID = table.Column<Guid>(type: "uuid", nullable: false),
+                    CategorizationRule = table.Column<string>(type: "text", nullable: false),
+                    Category = table.Column<string>(type: "text", nullable: false),
+                    UserID = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AutomaticCategorizationRule", x => x.ID);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AutomaticCategorizationRule");
+        }
+    }
+}

--- a/server/BudgetBoard.Database/Migrations/20250811030029_UpdateAutomaticCategorizationRule.Designer.cs
+++ b/server/BudgetBoard.Database/Migrations/20250811030029_UpdateAutomaticCategorizationRule.Designer.cs
@@ -4,6 +4,7 @@ using BudgetBoard.Database.Data;
 using BudgetBoard.Database.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BudgetBoard.Database.Migrations
 {
     [DbContext(typeof(UserDataContext))]
-    partial class UserDataContextModelSnapshot : ModelSnapshot
+    [Migration("20250811030029_UpdateAutomaticCategorizationRule")]
+    partial class UpdateAutomaticCategorizationRule
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/BudgetBoard.Database/Migrations/20250811030029_UpdateAutomaticCategorizationRule.cs
+++ b/server/BudgetBoard.Database/Migrations/20250811030029_UpdateAutomaticCategorizationRule.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BudgetBoard.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateAutomaticCategorizationRule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_AutomaticCategorizationRule_UserID",
+                table: "AutomaticCategorizationRule",
+                column: "UserID");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AutomaticCategorizationRule_User_UserID",
+                table: "AutomaticCategorizationRule",
+                column: "UserID",
+                principalTable: "User",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AutomaticCategorizationRule_User_UserID",
+                table: "AutomaticCategorizationRule");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AutomaticCategorizationRule_UserID",
+                table: "AutomaticCategorizationRule");
+        }
+    }
+}

--- a/server/BudgetBoard.Database/Models/ApplicationUser.cs
+++ b/server/BudgetBoard.Database/Models/ApplicationUser.cs
@@ -12,4 +12,5 @@ public class ApplicationUser : IdentityUser<Guid>
     public ICollection<Category> TransactionCategories { get; set; } = [];
     public ICollection<Institution> Institutions { get; set; } = [];
     public UserSettings? UserSettings { get; set; } = null!;
+    public ICollection<AutomaticCategorizationRule> AutomaticCategorizationRules { get; set; } = [];
 }

--- a/server/BudgetBoard.Database/Models/AutomaticCategorizationRule.cs
+++ b/server/BudgetBoard.Database/Models/AutomaticCategorizationRule.cs
@@ -5,5 +5,6 @@ public class AutomaticCategorizationRule()
     public Guid ID { get; set; }
     public string CategorizationRule { get; set; } = string.Empty;
     public string Category { get; set; } = string.Empty;
+    public ApplicationUser? User { get; set; } = null!;
     public Guid UserID { get; set; }
 }

--- a/server/BudgetBoard.Database/Models/AutomaticCategorizationRule.cs
+++ b/server/BudgetBoard.Database/Models/AutomaticCategorizationRule.cs
@@ -1,0 +1,9 @@
+﻿namespace BudgetBoard.Database.Models;
+
+public class AutomaticCategorizationRule()
+{
+    public Guid ID { get; set; }
+    public string CategorizationRule { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public Guid UserID { get; set; }
+}

--- a/server/BudgetBoard.Service/AutomaticCategorizationRuleService.cs
+++ b/server/BudgetBoard.Service/AutomaticCategorizationRuleService.cs
@@ -22,6 +22,22 @@ public class AutomaticCategorizationRuleService(
     {
         var userData = await GetCurrentUserAsync(userGuid.ToString());
 
+        if (string.IsNullOrWhiteSpace(rule.CategorizationRule))
+        {
+            _logger.LogError(
+                "Attempt to create an automatic categorization rule with an empty rule."
+            );
+            throw new BudgetBoardServiceException("Rule cannot be empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(rule.Category))
+        {
+            _logger.LogError(
+                "Attempt to create an automatic categorization rule with an empty category."
+            );
+            throw new BudgetBoardServiceException("Category cannot be empty.");
+        }
+
         try
         {
             _ = new System.Text.RegularExpressions.Regex(rule.CategorizationRule);

--- a/server/BudgetBoard.Service/AutomaticCategorizationRuleService.cs
+++ b/server/BudgetBoard.Service/AutomaticCategorizationRuleService.cs
@@ -1,0 +1,171 @@
+﻿using BudgetBoard.Database.Data;
+using BudgetBoard.Database.Models;
+using BudgetBoard.Service.Interfaces;
+using BudgetBoard.Service.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace BudgetBoard.Service;
+
+public class AutomaticCategorizationRuleService(
+    ILogger<IAutomaticCategorizationRuleService> logger,
+    UserDataContext userDataContext
+) : IAutomaticCategorizationRuleService
+{
+    private readonly ILogger<IAutomaticCategorizationRuleService> _logger = logger;
+    private readonly UserDataContext _userDataContext = userDataContext;
+
+    public async Task CreateAutomaticCategorizationRuleAsync(
+        Guid userGuid,
+        IAutomaticCategorizationRuleRequest rule
+    )
+    {
+        var userData = await GetCurrentUserAsync(userGuid.ToString());
+
+        try
+        {
+            _ = new System.Text.RegularExpressions.Regex(rule.CategorizationRule);
+        }
+        catch (System.Text.RegularExpressions.RegexParseException ex)
+        {
+            _logger.LogError(
+                "Invalid regex in automatic categorization rule: {ExceptionMessage}",
+                ex.Message
+            );
+            throw new BudgetBoardServiceException(
+                "Invalid regex in automatic categorization rule."
+            );
+        }
+
+        if (
+            userData.AutomaticCategorizationRules.Any(r =>
+                r.CategorizationRule == rule.CategorizationRule
+            )
+        )
+        {
+            _logger.LogError(
+                "Attempt to create an automatic categorization rule that already exists."
+            );
+            throw new BudgetBoardServiceException(
+                "An automatic categorization rule with this regex already exists."
+            );
+        }
+
+        if (
+            !TransactionCategoriesConstants.DefaultTransactionCategories.Any(c =>
+                c.Value == rule.Category
+            )
+            && !userData.TransactionCategories.Any(c =>
+                c.Value.Equals(rule.Category, StringComparison.InvariantCultureIgnoreCase)
+            )
+        )
+        {
+            _logger.LogError(
+                "Attempt to create an automatic categorization rule with an invalid category."
+            );
+            throw new BudgetBoardServiceException("Invalid category provided.");
+        }
+
+        var newRule = new AutomaticCategorizationRule
+        {
+            ID = Guid.NewGuid(),
+            UserID = userData.Id,
+            CategorizationRule = rule.CategorizationRule,
+            Category = rule.Category,
+        };
+
+        _userDataContext.AutomaticCategorizationRules.Add(newRule);
+        try
+        {
+            await _userDataContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                "An error occurred while saving the automatic categorization rule: {ExceptionMessage}",
+                ex.Message
+            );
+            throw new BudgetBoardServiceException(
+                "An error occurred while saving the automatic categorization rule."
+            );
+        }
+    }
+
+    public async Task<
+        IEnumerable<IAutomaticCategorizationRuleResponse>
+    > ReadAutomaticCategorizationRulesAsync(Guid userGuid)
+    {
+        var userData = await GetCurrentUserAsync(userGuid.ToString());
+        return userData.AutomaticCategorizationRules.Select(
+            r => new AutomaticCategorizationRuleResponse
+            {
+                ID = r.ID,
+                CategorizationRule = r.CategorizationRule,
+                Category = r.Category,
+            }
+        );
+    }
+
+    public async Task DeleteAutomaticCategorizationRuleAsync(Guid userGuid, Guid ruleGuid)
+    {
+        var userData = await GetCurrentUserAsync(userGuid.ToString());
+
+        var rule = userData.AutomaticCategorizationRules.FirstOrDefault(r => r.ID == ruleGuid);
+        if (rule == null)
+        {
+            _logger.LogError(
+                "Attempt to delete an automatic categorization rule that does not exist."
+            );
+            throw new BudgetBoardServiceException("Automatic categorization rule not found.");
+        }
+
+        userData.AutomaticCategorizationRules.Remove(rule);
+        try
+        {
+            await _userDataContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                "An error occurred while deleting the automatic categorization rule: {ExceptionMessage}",
+                ex.Message
+            );
+            throw new BudgetBoardServiceException(
+                "An error occurred while deleting the automatic categorization rule."
+            );
+        }
+    }
+
+    private async Task<ApplicationUser> GetCurrentUserAsync(string id)
+    {
+        List<ApplicationUser> users;
+        ApplicationUser? foundUser;
+        try
+        {
+            users = await _userDataContext
+                .ApplicationUsers.Include(u => u.AutomaticCategorizationRules)
+                .Include(u => u.TransactionCategories)
+                .AsSplitQuery()
+                .ToListAsync();
+            foundUser = users.FirstOrDefault(u => u.Id == new Guid(id));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                "An error occurred while retrieving the user data: {ExceptionMessage}",
+                ex.Message
+            );
+            throw new BudgetBoardServiceException(
+                "An error occurred while retrieving the user data."
+            );
+        }
+
+        if (foundUser == null)
+        {
+            _logger.LogError("Attempt to create an account for an invalid user.");
+            throw new BudgetBoardServiceException("Provided user not found.");
+        }
+
+        return foundUser;
+    }
+}

--- a/server/BudgetBoard.Service/BudgetBoard.Service.csproj
+++ b/server/BudgetBoard.Service/BudgetBoard.Service.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/server/BudgetBoard.Service/Interfaces/IAutomaticCategorizationRuleService.cs
+++ b/server/BudgetBoard.Service/Interfaces/IAutomaticCategorizationRuleService.cs
@@ -1,0 +1,15 @@
+﻿using BudgetBoard.Service.Models;
+
+namespace BudgetBoard.Service.Interfaces;
+
+public interface IAutomaticCategorizationRuleService
+{
+    Task CreateAutomaticCategorizationRuleAsync(
+        Guid userGuid,
+        IAutomaticCategorizationRuleRequest rule
+    );
+    Task<IEnumerable<IAutomaticCategorizationRuleResponse>> ReadAutomaticCategorizationRulesAsync(
+        Guid userGuid
+    );
+    Task DeleteAutomaticCategorizationRuleAsync(Guid userGuid, Guid ruleGuid);
+}

--- a/server/BudgetBoard.Service/Models/AutomaticCategorizationRule.cs
+++ b/server/BudgetBoard.Service/Models/AutomaticCategorizationRule.cs
@@ -1,0 +1,27 @@
+﻿namespace BudgetBoard.Service.Models;
+
+public interface IAutomaticCategorizationRuleRequest
+{
+    string CategorizationRule { get; set; }
+    string Category { get; set; }
+}
+
+public class AutomaticCategorizationRuleRequest() : IAutomaticCategorizationRuleRequest
+{
+    public string CategorizationRule { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+}
+
+public interface IAutomaticCategorizationRuleResponse
+{
+    Guid ID { get; set; }
+    string CategorizationRule { get; set; }
+    string Category { get; set; }
+}
+
+public class AutomaticCategorizationRuleResponse() : IAutomaticCategorizationRuleResponse
+{
+    public Guid ID { get; set; }
+    public string CategorizationRule { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+}

--- a/server/BudgetBoard.Service/SimpleFinService.cs
+++ b/server/BudgetBoard.Service/SimpleFinService.cs
@@ -484,9 +484,9 @@ public class SimpleFinService(
 
         foreach (var ruleRegex in compiledRuleRegexes)
         {
-            var matchingTransactions = uncategorizedTransactions.Where(t =>
-                ruleRegex.Regex.IsMatch(t.MerchantName ?? string.Empty)
-            );
+            var matchingTransactions = uncategorizedTransactions
+                .Where(t => ruleRegex.Regex.IsMatch(t.MerchantName ?? string.Empty))
+                .ToList();
 
             foreach (var transaction in matchingTransactions)
             {

--- a/server/BudgetBoard.Tests/AutomaticCategorizationRuleTests.cs
+++ b/server/BudgetBoard.Tests/AutomaticCategorizationRuleTests.cs
@@ -1,0 +1,42 @@
+﻿using BudgetBoard.Service;
+using BudgetBoard.Service.Interfaces;
+using BudgetBoard.Service.Models;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace BudgetBoard.IntegrationTests;
+
+[Collection("IntegrationTests")]
+public class AutomaticCategorizationRuleTests
+{
+    [Fact]
+    public async Task CreateAutomaticCategorizationRuleAsync_WhenRuleIsValid_CreatesRule()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
+
+        var rule = new AutomaticCategorizationRuleRequest
+        {
+            CategorizationRule = ".*test.*",
+            Category = TransactionCategoriesConstants.DefaultTransactionCategories.First().Value,
+        };
+
+        // Act
+        await automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+            helper.demoUser.Id,
+            rule
+        );
+
+        // Assert
+        helper.demoUser.AutomaticCategorizationRules.Should().HaveCount(1);
+        helper
+            .demoUser.AutomaticCategorizationRules.First()
+            .CategorizationRule.Should()
+            .Be(rule.CategorizationRule);
+    }
+}

--- a/server/BudgetBoard.Tests/AutomaticCategorizationRuleTests.cs
+++ b/server/BudgetBoard.Tests/AutomaticCategorizationRuleTests.cs
@@ -133,6 +133,64 @@ public class AutomaticCategorizationRuleTests
     }
 
     [Fact]
+    public async Task CreateAutomaticCategorizationRuleAsync_WhenCategoryIsEmpty_ThrowsException()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
+
+        var rule = new AutomaticCategorizationRuleRequest
+        {
+            CategorizationRule = ".*test.*",
+            Category = string.Empty,
+        };
+
+        // Act
+        Func<Task> act = async () =>
+            await automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+                helper.demoUser.Id,
+                rule
+            );
+
+        // Assert
+        await act.Should()
+            .ThrowAsync<BudgetBoardServiceException>()
+            .WithMessage("Category cannot be empty.");
+    }
+
+    [Fact]
+    public async Task CreateAutomaticCategorizationRuleAsync_WhenRuleIsEmpty_ThrowsException()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
+
+        var rule = new AutomaticCategorizationRuleRequest
+        {
+            CategorizationRule = string.Empty,
+            Category = TransactionCategoriesConstants.DefaultTransactionCategories.First().Value,
+        };
+
+        // Act
+        Func<Task> act = async () =>
+            await automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+                helper.demoUser.Id,
+                rule
+            );
+
+        // Assert
+        await act.Should()
+            .ThrowAsync<BudgetBoardServiceException>()
+            .WithMessage("Rule cannot be empty.");
+    }
+
+    [Fact]
     public async Task ReadAutomaticCategorizationRulesAsync_WhenCalled_ReturnsRules()
     {
         // Arrange

--- a/server/BudgetBoard.Tests/AutomaticCategorizationRuleTests.cs
+++ b/server/BudgetBoard.Tests/AutomaticCategorizationRuleTests.cs
@@ -39,4 +39,181 @@ public class AutomaticCategorizationRuleTests
             .CategorizationRule.Should()
             .Be(rule.CategorizationRule);
     }
+
+    [Fact]
+    public async Task CreateAutomaticCategorizationRuleAsync_WhenRuleIsInvalid_ThrowsException()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
+
+        var rule = new AutomaticCategorizationRuleRequest
+        {
+            CategorizationRule = "invalid regex[",
+            Category = TransactionCategoriesConstants.DefaultTransactionCategories.First().Value,
+        };
+
+        // Act
+        Func<Task> act = async () =>
+            await automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+                helper.demoUser.Id,
+                rule
+            );
+
+        // Assert
+        await act.Should()
+            .ThrowAsync<BudgetBoardServiceException>()
+            .WithMessage("Invalid regex in automatic categorization rule.");
+    }
+
+    [Fact]
+    public async Task CreateAutomaticCategorizationRuleAsync_WhenRuleAlreadyExists_ThrowsException()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
+
+        var rule = new AutomaticCategorizationRuleRequest
+        {
+            CategorizationRule = ".*test.*",
+            Category = TransactionCategoriesConstants.DefaultTransactionCategories.First().Value,
+        };
+
+        await automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+            helper.demoUser.Id,
+            rule
+        );
+
+        // Act
+        Func<Task> act = async () =>
+            await automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+                helper.demoUser.Id,
+                rule
+            );
+
+        // Assert
+        await act.Should()
+            .ThrowAsync<BudgetBoardServiceException>()
+            .WithMessage("An automatic categorization rule with this regex already exists.");
+    }
+
+    [Fact]
+    public async Task CreateAutomaticCategorizationRuleAsync_WhenCategoryIsInvalid_ThrowsException()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
+
+        var rule = new AutomaticCategorizationRuleRequest
+        {
+            CategorizationRule = ".*test.*",
+            Category = "InvalidCategory",
+        };
+
+        // Act
+        Func<Task> act = async () =>
+            await automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+                helper.demoUser.Id,
+                rule
+            );
+
+        // Assert
+        await act.Should()
+            .ThrowAsync<BudgetBoardServiceException>()
+            .WithMessage("Invalid category provided.");
+    }
+
+    [Fact]
+    public async Task ReadAutomaticCategorizationRulesAsync_WhenCalled_ReturnsRules()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
+
+        var rule = new AutomaticCategorizationRuleRequest
+        {
+            CategorizationRule = ".*test.*",
+            Category = TransactionCategoriesConstants.DefaultTransactionCategories.First().Value,
+        };
+
+        await automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+            helper.demoUser.Id,
+            rule
+        );
+
+        // Act
+        var rules = await automaticCategorizationRuleService.ReadAutomaticCategorizationRulesAsync(
+            helper.demoUser.Id
+        );
+
+        // Assert
+        rules.Should().HaveCount(1);
+        rules.First().CategorizationRule.Should().Be(rule.CategorizationRule);
+    }
+
+    [Fact]
+    public async Task DeleteAutomaticCategorizationRuleAsync_WhenRuleExists_DeletesRule()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
+
+        var rule = new AutomaticCategorizationRuleRequest
+        {
+            CategorizationRule = ".*test.*",
+            Category = TransactionCategoriesConstants.DefaultTransactionCategories.First().Value,
+        };
+
+        await automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+            helper.demoUser.Id,
+            rule
+        );
+
+        // Act
+        await automaticCategorizationRuleService.DeleteAutomaticCategorizationRuleAsync(
+            helper.demoUser.Id,
+            helper.demoUser.AutomaticCategorizationRules.First().ID
+        );
+
+        // Assert
+        helper.demoUser.AutomaticCategorizationRules.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteAutomaticCategorizationRuleAsync_WhenRuleDoesNotExist_ThrowsException()
+    {
+        // Arrange
+        var helper = new TestHelper();
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
+
+        // Act
+        Func<Task> act = async () =>
+            await automaticCategorizationRuleService.DeleteAutomaticCategorizationRuleAsync(
+                helper.demoUser.Id,
+                Guid.NewGuid() // Non-existent rule ID
+            );
+
+        // Assert
+        await act.Should()
+            .ThrowAsync<BudgetBoardServiceException>()
+            .WithMessage("Automatic categorization rule not found.");
+    }
 }

--- a/server/BudgetBoard.Tests/BudgetBoard.IntegrationTests.csproj
+++ b/server/BudgetBoard.Tests/BudgetBoard.IntegrationTests.csproj
@@ -12,11 +12,11 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.3" />
     <PackageReference Include="FluentAssertions" Version="8.5.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
+++ b/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
@@ -38,6 +38,7 @@ public class SimpleFinServiceTests
             Mock.Of<IBalanceService>(),
             Mock.Of<IGoalService>(),
             Mock.Of<IApplicationUserService>(),
+            Mock.Of<IAutomaticCategorizationRuleService>(),
             Mock.Of<INowProvider>()
         );
 
@@ -99,6 +100,10 @@ public class SimpleFinServiceTests
             Mock.Of<ILogger<IApplicationUserService>>(),
             helper.UserDataContext
         );
+        var automaticCategorizationRuleService = new AutomaticCategorizationRuleService(
+            Mock.Of<ILogger<IAutomaticCategorizationRuleService>>(),
+            helper.UserDataContext
+        );
 
         var fakeDate = new Faker().Date.Past().ToUniversalTime();
 
@@ -115,6 +120,7 @@ public class SimpleFinServiceTests
             balanceService,
             goalService,
             applicationUserService,
+            automaticCategorizationRuleService,
             nowProvider
         );
 

--- a/server/BudgetBoard.Tests/TransactionServiceTests.cs
+++ b/server/BudgetBoard.Tests/TransactionServiceTests.cs
@@ -66,6 +66,7 @@ public class TransactionServiceTests
 
         var transaction = _transactionCreateRequestFaker.Generate();
         transaction.AccountID = account.ID;
+        transaction.Date = transaction.Date.ToUniversalTime();
 
         // Act
         await transactionService.CreateTransactionAsync(helper.demoUser.Id, transaction);
@@ -124,7 +125,10 @@ public class TransactionServiceTests
         await transactionService.CreateTransactionAsync(helper.demoUser.Id, transaction);
         // Assert
         helper.UserDataContext.Balances.Should().ContainSingle();
-        helper.UserDataContext.Balances.Single().DateTime.Should().Be(transaction.Date);
+        helper
+            .UserDataContext.Balances.Single()
+            .DateTime.Should()
+            .Be(transaction.Date.ToUniversalTime());
         helper.UserDataContext.Balances.Single().Amount.Should().Be(transaction.Amount);
     }
 
@@ -443,7 +447,7 @@ public class TransactionServiceTests
         {
             ID = transactions.First().ID,
             Amount = 100.0M,
-            Date = new Faker().Date.Past(),
+            Date = new Faker().Date.Past().ToUniversalTime(),
             Category = "newCategory",
             Subcategory = "newSubcategory",
             MerchantName = "newMerchantName",

--- a/server/BudgetBoard.WebAPI/BudgetBoard.WebAPI.csproj
+++ b/server/BudgetBoard.WebAPI/BudgetBoard.WebAPI.csproj
@@ -17,28 +17,28 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-    <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.14.0" />
-    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.14.0" />
+    <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.15.0" />
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.15.0" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.7" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/server/BudgetBoard.WebAPI/Controllers/AutomaticCategorizationRuleController.cs
+++ b/server/BudgetBoard.WebAPI/Controllers/AutomaticCategorizationRuleController.cs
@@ -1,0 +1,94 @@
+﻿using BudgetBoard.Database.Models;
+using BudgetBoard.Service.Interfaces;
+using BudgetBoard.Service.Models;
+using BudgetBoard.WebAPI.Utils;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BudgetBoard.WebAPI.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class AutomaticCategorizationRuleController(
+    ILogger<AutomaticCategorizationRuleController> logger,
+    UserManager<ApplicationUser> userManager,
+    IAutomaticCategorizationRuleService automaticCategorizationRuleService
+) : ControllerBase
+{
+    private readonly ILogger<AutomaticCategorizationRuleController> _logger = logger;
+    private readonly UserManager<ApplicationUser> _userManager = userManager;
+    private readonly IAutomaticCategorizationRuleService _automaticCategorizationRuleService =
+        automaticCategorizationRuleService;
+
+    [HttpPost]
+    [Authorize]
+    public async Task<IActionResult> Create(
+        [FromBody] AutomaticCategorizationRuleRequest automaticCategorizationRule
+    )
+    {
+        try
+        {
+            await _automaticCategorizationRuleService.CreateAutomaticCategorizationRuleAsync(
+                new Guid(_userManager.GetUserId(User) ?? string.Empty),
+                automaticCategorizationRule
+            );
+            return Ok();
+        }
+        catch (BudgetBoardServiceException bbex)
+        {
+            return Helpers.BuildErrorResponse(bbex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unexpected error occurred.");
+            return Helpers.BuildErrorResponse("An unexpected server error occurred.");
+        }
+    }
+
+    [HttpGet]
+    [Authorize]
+    public async Task<IActionResult> Read()
+    {
+        try
+        {
+            return Ok(
+                await _automaticCategorizationRuleService.ReadAutomaticCategorizationRulesAsync(
+                    new Guid(_userManager.GetUserId(User) ?? string.Empty)
+                )
+            );
+        }
+        catch (BudgetBoardServiceException bbex)
+        {
+            return Helpers.BuildErrorResponse(bbex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unexpected error occurred.");
+            return Helpers.BuildErrorResponse("An unexpected server error occurred.");
+        }
+    }
+
+    [HttpDelete]
+    [Authorize]
+    public async Task<IActionResult> Delete(Guid guid)
+    {
+        try
+        {
+            await _automaticCategorizationRuleService.DeleteAutomaticCategorizationRuleAsync(
+                new Guid(_userManager.GetUserId(User) ?? string.Empty),
+                guid
+            );
+            return Ok();
+        }
+        catch (BudgetBoardServiceException bbex)
+        {
+            return Helpers.BuildErrorResponse(bbex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An unexpected error occurred.");
+            return Helpers.BuildErrorResponse("An unexpected server error occurred.");
+        }
+    }
+}

--- a/server/BudgetBoard.WebAPI/Program.cs
+++ b/server/BudgetBoard.WebAPI/Program.cs
@@ -178,6 +178,10 @@ builder.Services.AddScoped<IInstitutionService, InstitutionService>();
 builder.Services.AddScoped<ISimpleFinService, SimpleFinService>();
 builder.Services.AddScoped<IApplicationUserService, ApplicationUserService>();
 builder.Services.AddScoped<IUserSettingsService, UserSettingsService>();
+builder.Services.AddScoped<
+    IAutomaticCategorizationRuleService,
+    AutomaticCategorizationRuleService
+>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
Added a feature to allow setting regex rules on the merchant name to automatically categorize transactions during sync.