### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image-pr-build.yml
+++ b/.github/workflows/docker-image-pr-build.yml
@@ -1,4 +1,6 @@
 name: Build Docker Images
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,8 @@
 name: Run Dotnet Unit Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
 


### PR DESCRIPTION
Potential fix for [https://github.com/teelur/budget-board/security/code-scanning/2](https://github.com/teelur/budget-board/security/code-scanning/2)

To fix this problem, explicitly add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to just those required for the job. For this workflow, the minimal necessary permission is `contents: read` (for checking out code). Write access is not needed as the workflow does not push Docker images to a registry, create PRs or issues, or interact with other repository resources. The permissions block can be added either at the workflow root (recommended, since only one job is present), typically immediately after the `name:` declaration and before `on:`. No new imports or methods are required; just a simple modification to the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
