### PR TITLE
Potential fix for code scanning alert no. 3: User-controlled bypass of sensitive method

### DIFF
--- a/server/BudgetBoard.WebAPI/Program.cs
+++ b/server/BudgetBoard.WebAPI/Program.cs
@@ -216,14 +216,10 @@ app.UseAuthorization();
 
 app.MapPost(
         "/api/logout",
-        async (SignInManager<ApplicationUser> signInManager, [FromBody] object empty) =>
+        async (SignInManager<ApplicationUser> signInManager) =>
         {
-            if (empty != null)
-            {
-                await signInManager.SignOutAsync();
-                return Results.Ok();
-            }
-            return Results.Unauthorized();
+            await signInManager.SignOutAsync();
+            return Results.Ok();
         }
     )
     .RequireAuthorization(); // So that only authorized users can use this endpoint


### PR DESCRIPTION
Potential fix for [https://github.com/teelur/budget-board/security/code-scanning/3](https://github.com/teelur/budget-board/security/code-scanning/3)

**General approach:**  
Eliminate any control of the sensitive action (logout) by user-provided data. In particular, do not check for `empty != null`. Instead, always call `signInManager.SignOutAsync()` for any authenticated user who POSTs to `/api/logout`.

**Detailed steps:**  
- Remove the `if (empty != null)` condition from the `/api/logout` route handler.
- Always call `await signInManager.SignOutAsync();` and return `Results.Ok();` in the handler.
- The handler should still require authorization.
- There is no need to accept or consume any request body for logout operations, but you may keep or remove the `[FromBody] object empty` parameter as needed based on framework requirements. If removing it does not break routing/model binding, do so.

**Files/regions to change:**  
- Only lines within the `/api/logout` route handler in `server/BudgetBoard.WebAPI/Program.cs` (starting at line 217 and spanning lines 219-227).

**Needed imports/methods/definitions:**  
- No new imports or methods needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
