### PR TITLE
Tweak budget colors

### DIFF
--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetTotalCard/BudgetTotalCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetTotalCard/BudgetTotalCard.tsx
@@ -8,6 +8,7 @@ import { ITransaction } from "~/models/transaction";
 import { ICategory } from "~/models/category";
 import { areStringsEqual } from "~/helpers/utils";
 import { sumTransactionAmounts } from "~/helpers/transactions";
+import { BudgetValueType } from "~/helpers/budgets";
 
 interface BudgetTotalCardProps {
   incomeCategories: ICategory[];
@@ -80,19 +81,19 @@ const BudgetTotalCard = (props: BudgetTotalCardProps): React.ReactNode => {
               label="Income"
               amount={incomeTransactionsTotal}
               total={incomeBudgetsTotal}
-              isIncome
+              budgetValueType={BudgetValueType.Income}
             />
             <BudgetTotalItem
               label="Expenses"
               amount={expenseTransactionsTotal}
               total={expenseBudgetsTotal}
-              isIncome={false}
+              budgetValueType={BudgetValueType.Expense}
             />
             <BudgetTotalItem
               label="Unbudgeted"
               amount={unbudgetedTransactionsTotal}
               total={incomeBudgetsTotal - expenseBudgetsTotal}
-              isIncome
+              budgetValueType={BudgetValueType.Total}
               hideProgress
             />
           </Card>
@@ -104,7 +105,7 @@ const BudgetTotalCard = (props: BudgetTotalCardProps): React.ReactNode => {
             <BudgetTotalItem
               label="Net Cash Flow"
               amount={totalTransactionsTotal}
-              isIncome
+              budgetValueType={BudgetValueType.Total}
               hideProgress
             />
           </Card>

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetTotalCard/BudgetTotalItem/BudgetTotalItem.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetTotalCard/BudgetTotalItem/BudgetTotalItem.tsx
@@ -56,7 +56,8 @@ const BudgetTotalItem = (props: BudgetTotalItemProps): React.ReactNode => {
               c={getBudgetValueColor(
                 props.amount,
                 props.total ?? 0,
-                props.budgetValueType
+                props.budgetValueType,
+                userSettingsQuery.data?.budgetWarningThreshold ?? 80
               )}
             >
               {convertNumberToCurrency(
@@ -86,7 +87,8 @@ const BudgetTotalItem = (props: BudgetTotalItemProps): React.ReactNode => {
             color={getBudgetValueColor(
               props.amount,
               props.total ?? 0,
-              props.budgetValueType
+              props.budgetValueType,
+              userSettingsQuery.data?.budgetWarningThreshold ?? 80
             )}
           >
             <Progress.Label>{percentComplete.toFixed(0)}%</Progress.Label>

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetTotalCard/BudgetTotalItem/BudgetTotalItem.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetTotalCard/BudgetTotalItem/BudgetTotalItem.tsx
@@ -1,6 +1,6 @@
 import classes from "./BudgetTotalItem.module.css";
 
-import { getBudgetValueColor } from "~/helpers/budgets";
+import { BudgetValueType, getBudgetValueColor } from "~/helpers/budgets";
 import { convertNumberToCurrency } from "~/helpers/currency";
 import { Flex, Group, Progress, Stack, Text } from "@mantine/core";
 import React from "react";
@@ -13,7 +13,7 @@ interface BudgetTotalItemProps {
   label: string;
   amount: number;
   total?: number;
-  isIncome: boolean;
+  budgetValueType: BudgetValueType;
   hideProgress?: boolean;
 }
 
@@ -37,7 +37,10 @@ const BudgetTotalItem = (props: BudgetTotalItemProps): React.ReactNode => {
   });
 
   const percentComplete = Math.round(
-    ((props.amount * (props.isIncome ? 1 : -1)) / (props.total ?? 0)) * 100
+    ((props.amount *
+      (props.budgetValueType === BudgetValueType.Expense ? -1 : 1)) /
+      (props.total ?? 0)) *
+      100
   );
 
   return (
@@ -53,11 +56,12 @@ const BudgetTotalItem = (props: BudgetTotalItemProps): React.ReactNode => {
               c={getBudgetValueColor(
                 props.amount,
                 props.total ?? 0,
-                props.isIncome
+                props.budgetValueType
               )}
             >
               {convertNumberToCurrency(
-                props.amount * (props.isIncome ? 1 : -1),
+                props.amount *
+                  (props.budgetValueType === BudgetValueType.Expense ? -1 : 1),
                 false,
                 userSettingsQuery.data?.currency ?? "USD"
               )}
@@ -82,7 +86,7 @@ const BudgetTotalItem = (props: BudgetTotalItemProps): React.ReactNode => {
             color={getBudgetValueColor(
               props.amount,
               props.total ?? 0,
-              props.isIncome
+              props.budgetValueType
             )}
           >
             <Progress.Label>{percentComplete.toFixed(0)}%</Progress.Label>

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/BudgetChildCard/BudgetChildCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/BudgetChildCard/BudgetChildCard.tsx
@@ -16,7 +16,7 @@ import { IBudget, IBudgetUpdateRequest } from "~/models/budget";
 import React from "react";
 import { useField } from "@mantine/form";
 import { CornerDownRight, PencilIcon, TrashIcon } from "lucide-react";
-import { getBudgetValueColor } from "~/helpers/budgets";
+import { BudgetValueType, getBudgetValueColor } from "~/helpers/budgets";
 import { roundAwayFromZero } from "~/helpers/utils";
 import { useDisclosure } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
@@ -229,6 +229,8 @@ const BudgetChildCard = (props: BudgetChildCardProps): React.ReactNode => {
                       roundAwayFromZero(props.amount),
                       props.limit,
                       props.isIncome
+                        ? BudgetValueType.Income
+                        : BudgetValueType.Expense
                     )}
                   >
                     <Progress.Label>
@@ -245,6 +247,8 @@ const BudgetChildCard = (props: BudgetChildCardProps): React.ReactNode => {
                     roundAwayFromZero(props.amount),
                     props.limit,
                     props.isIncome
+                      ? BudgetValueType.Income
+                      : BudgetValueType.Expense
                   )}
                 >
                   {convertNumberToCurrency(

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/BudgetChildCard/BudgetChildCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/BudgetChildCard/BudgetChildCard.tsx
@@ -230,7 +230,8 @@ const BudgetChildCard = (props: BudgetChildCardProps): React.ReactNode => {
                       props.limit,
                       props.isIncome
                         ? BudgetValueType.Income
-                        : BudgetValueType.Expense
+                        : BudgetValueType.Expense,
+                      userSettingsQuery.data?.budgetWarningThreshold ?? 80
                     )}
                   >
                     <Progress.Label>
@@ -248,7 +249,8 @@ const BudgetChildCard = (props: BudgetChildCardProps): React.ReactNode => {
                     props.limit,
                     props.isIncome
                       ? BudgetValueType.Income
-                      : BudgetValueType.Expense
+                      : BudgetValueType.Expense,
+                    userSettingsQuery.data?.budgetWarningThreshold ?? 80
                   )}
                 >
                   {convertNumberToCurrency(

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/BudgetParentCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/BudgetParentCard.tsx
@@ -334,7 +334,8 @@ const BudgetParentCard = (props: BudgetParentCardProps): React.ReactNode => {
                         limit,
                         isIncome
                           ? BudgetValueType.Income
-                          : BudgetValueType.Expense
+                          : BudgetValueType.Expense,
+                        userSettingsQuery.data?.budgetWarningThreshold ?? 80
                       )}
                     >
                       <Progress.Label>
@@ -352,7 +353,8 @@ const BudgetParentCard = (props: BudgetParentCardProps): React.ReactNode => {
                       limit,
                       isIncome
                         ? BudgetValueType.Income
-                        : BudgetValueType.Expense
+                        : BudgetValueType.Expense,
+                      userSettingsQuery.data?.budgetWarningThreshold ?? 80
                     )}
                   >
                     {convertNumberToCurrency(

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/BudgetParentCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/BudgetParentCard.tsx
@@ -19,7 +19,7 @@ import React from "react";
 import { useDisclosure } from "@mantine/hooks";
 import { useField } from "@mantine/form";
 import { PencilIcon, TrashIcon } from "lucide-react";
-import { getBudgetValueColor } from "~/helpers/budgets";
+import { getBudgetValueColor, BudgetValueType } from "~/helpers/budgets";
 import { areStringsEqual, roundAwayFromZero } from "~/helpers/utils";
 import { ICategoryNode } from "~/models/category";
 import BudgetChildCard from "./BudgetChildCard/BudgetChildCard";
@@ -333,6 +333,8 @@ const BudgetParentCard = (props: BudgetParentCardProps): React.ReactNode => {
                         roundAwayFromZero(amount),
                         limit,
                         isIncome
+                          ? BudgetValueType.Income
+                          : BudgetValueType.Expense
                       )}
                     >
                       <Progress.Label>
@@ -349,6 +351,8 @@ const BudgetParentCard = (props: BudgetParentCardProps): React.ReactNode => {
                       roundAwayFromZero(amount),
                       limit,
                       isIncome
+                        ? BudgetValueType.Income
+                        : BudgetValueType.Expense
                     )}
                   >
                     {convertNumberToCurrency(

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/AddBudget/AddBudget.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/AddBudget/AddBudget.tsx
@@ -5,7 +5,6 @@ import CategorySelect from "~/components/CategorySelect";
 import { translateAxiosError } from "~/helpers/requests";
 import {
   ActionIcon,
-  Button,
   LoadingOverlay,
   NumberInput,
   Popover,
@@ -98,9 +97,9 @@ const AddBudget = (props: AddBudgetProps): React.ReactNode => {
   return (
     <Popover>
       <Popover.Target>
-        <Button>
+        <ActionIcon size="input-sm">
           <PlusIcon />
-        </Button>
+        </ActionIcon>
       </Popover.Target>
       <Popover.Dropdown className={classes.root}>
         <LoadingOverlay visible={doCreateBudget.isPending} />

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetSettings/BudgetSettings.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetSettings/BudgetSettings.tsx
@@ -1,0 +1,134 @@
+import {
+  ActionIcon,
+  Flex,
+  Group,
+  Modal,
+  NumberInput,
+  Text,
+} from "@mantine/core";
+import { useField } from "@mantine/form";
+import { useDisclosure } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
+import { SendIcon, SettingsIcon } from "lucide-react";
+import React from "react";
+import { AuthContext } from "~/components/AuthProvider/AuthProvider";
+import { translateAxiosError } from "~/helpers/requests";
+import {
+  IUserSettings,
+  IUserSettingsUpdateRequest,
+} from "~/models/userSettings";
+
+const BudgetSettings = (): React.ReactNode => {
+  const [settingsOpen, { open, close }] = useDisclosure(false);
+
+  const { request } = React.useContext<any>(AuthContext);
+
+  const userSettingsQuery = useQuery({
+    queryKey: ["userSettings"],
+    queryFn: async (): Promise<IUserSettings | undefined> => {
+      const res: AxiosResponse = await request({
+        url: "/api/userSettings",
+        method: "GET",
+      });
+
+      if (res.status === 200) {
+        return res.data as IUserSettings;
+      }
+
+      return undefined;
+    },
+  });
+
+  const budgetWarningThresholdField = useField<number>({
+    initialValue: userSettingsQuery.data?.budgetWarningThreshold ?? 80,
+    validate: (value) =>
+      value < 0 || value > 100
+        ? "Warning threshold must be between 0 and 100"
+        : null,
+  });
+
+  const queryClient = useQueryClient();
+  const doUpdateUserSettings = useMutation({
+    mutationFn: async (updatedUserSettings: IUserSettingsUpdateRequest) =>
+      await request({
+        url: "/api/userSettings",
+        method: "PUT",
+        data: updatedUserSettings,
+      }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["userSettings"] });
+      notifications.show({ message: "Settings updated", color: "green" });
+    },
+    onError: (error: any) => {
+      notifications.show({
+        color: "red",
+        message: translateAxiosError(error),
+      });
+    },
+  });
+
+  React.useEffect(() => {
+    if (userSettingsQuery.data) {
+      budgetWarningThresholdField.setValue(
+        userSettingsQuery.data.budgetWarningThreshold
+      );
+    }
+  }, [userSettingsQuery.data]);
+  return (
+    <>
+      <ActionIcon
+        variant="subtle"
+        size="input-sm"
+        onClick={open}
+        aria-label="Open budget settings"
+      >
+        <SettingsIcon />
+      </ActionIcon>
+      <Modal
+        opened={settingsOpen}
+        onClose={close}
+        title={<Text fw={600}>Budget Settings</Text>}
+      >
+        <Group gap="0.5rem">
+          <NumberInput
+            flex="1 1 auto"
+            label="Budget Warning Threshold"
+            description="Set the percentage threshold at which budgets will turn yellow."
+            min={0}
+            max={100}
+            suffix="%"
+            {...budgetWarningThresholdField.getInputProps()}
+          />
+          <Flex style={{ alignSelf: "stretch" }} p={0}>
+            <ActionIcon
+              h="100%"
+              size="md"
+              aria-label="Save settings"
+              onClick={() => {
+                if (budgetWarningThresholdField.error) {
+                  notifications.show({
+                    color: "red",
+                    message: budgetWarningThresholdField.error,
+                  });
+                  return;
+                }
+
+                doUpdateUserSettings.mutate({
+                  budgetWarningThreshold:
+                    budgetWarningThresholdField.getValue(),
+                });
+              }}
+              loading={doUpdateUserSettings.isPending}
+            >
+              <SendIcon size={20} />
+            </ActionIcon>
+          </Flex>
+        </Group>
+      </Modal>
+    </>
+  );
+};
+
+export default BudgetSettings;

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetSettings/BudgetSettings.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetSettings/BudgetSettings.tsx
@@ -91,7 +91,7 @@ const BudgetSettings = (): React.ReactNode => {
         onClose={close}
         title={<Text fw={600}>Budget Settings</Text>}
       >
-        <Group gap="0.5rem">
+        <Group gap="0.5rem" wrap="nowrap">
           <NumberInput
             flex="1 1 auto"
             label="Budget Warning Threshold"

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetsToolbar.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetsToolbar.tsx
@@ -105,7 +105,7 @@ const BudgetsToolbar = (props: BudgetsToolbarProps): React.ReactNode => {
         isPending={props.isPending}
         allowSelectMultiple={canSelectMultiple}
       />
-      <Group justify="space-between">
+      <Group justify="space-between" gap="0.5rem">
         <Button
           onClick={toggleSelectMultiple}
           variant="outline"
@@ -116,7 +116,7 @@ const BudgetsToolbar = (props: BudgetsToolbarProps): React.ReactNode => {
         <Group gap="0.5rem">
           {props.showCopy && (
             <Button onClick={onCopyBudgets} loading={doCopyBudget.isPending}>
-              Copy Previous Month
+              Copy Previous
             </Button>
           )}
           {props.selectedDates.length === 1 && (

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetsToolbar.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetsToolbar.tsx
@@ -11,6 +11,7 @@ import { IBudget, IBudgetCreateRequest } from "~/models/budget";
 import { AxiosError, AxiosResponse } from "axios";
 import { notifications } from "@mantine/notifications";
 import { translateAxiosError } from "~/helpers/requests";
+import BudgetSettings from "./BudgetSettings/BudgetSettings";
 
 interface BudgetsToolbarProps {
   categories: ICategory[];
@@ -124,6 +125,7 @@ const BudgetsToolbar = (props: BudgetsToolbarProps): React.ReactNode => {
               categories={props.categories}
             />
           )}
+          <BudgetSettings />
         </Group>
       </Group>
     </Stack>

--- a/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/ImportTransactionsModal/ImportTransactionsModal.tsx
+++ b/client/src/app/Authorized/PageContent/Transactions/TransactionsHeader/ImportTransactionsModal/ImportTransactionsModal.tsx
@@ -161,6 +161,13 @@ const ImportTransactionsModal = () => {
         size="auto"
         p="0.5rem"
         title={<Text fw={600}>Import Transactions</Text>}
+        styles={{
+          inner: {
+            left: "0",
+            right: "0",
+            padding: "0 !important",
+          },
+        }}
       >
         <Stepper
           active={activeStep}

--- a/client/src/helpers/budgets.ts
+++ b/client/src/helpers/budgets.ts
@@ -138,7 +138,8 @@ export enum BudgetValueType {
 export const getBudgetValueColor = (
   amount: number,
   total: number,
-  type: BudgetValueType
+  type: BudgetValueType,
+  warningThreshold: number
 ): string => {
   if (type === BudgetValueType.Income) {
     if (amount < total) {
@@ -153,7 +154,7 @@ export const getBudgetValueColor = (
       if (invertedAmount >= total) {
         return "red";
       }
-      if (invertedAmount >= total * 0.8) {
+      if (invertedAmount >= total * (warningThreshold / 100)) {
         return "yellow";
       }
       return "green";

--- a/client/src/helpers/budgets.ts
+++ b/client/src/helpers/budgets.ts
@@ -129,30 +129,46 @@ export const sumBudgetAmounts = (budgetData: IBudget[]): number => {
   return budgetData.reduce((n, { limit }) => n + limit, 0);
 };
 
-/**
- * Determines the color for a budget value based on the completion percentage
- * and whether it represents income.
- *
- * @param {number} percentComplete - The completion percentage of the budget.
- * @param {boolean} isIncome - Indicates if the budget is for income (true) or spending (false).
- * @returns {string} - The color ("red" or "green") to visually represent the budget status.
- */
+export enum BudgetValueType {
+  Expense,
+  Income,
+  Total,
+}
+
 export const getBudgetValueColor = (
   amount: number,
   total: number,
-  isIncome: boolean
+  type: BudgetValueType
 ): string => {
-  if (isIncome) {
+  if (type === BudgetValueType.Income) {
     if (amount < total) {
-      return "red";
+      return "var(--mantine-primary-color-light-color)";
     }
     return "green";
   }
 
-  if (amount * -1 <= total) {
-    return "green";
+  if (type === BudgetValueType.Expense) {
+    {
+      const invertedAmount = amount * -1;
+      if (invertedAmount >= total) {
+        return "red";
+      }
+      if (invertedAmount >= total * 0.8) {
+        return "yellow";
+      }
+      return "green";
+    }
   }
-  return "red";
+
+  if (type === BudgetValueType.Total) {
+    if (amount < 0) {
+      return "red";
+    } else if (amount > 0) {
+      return "green";
+    }
+  }
+
+  return "var(--mantine-color-text)";
 };
 
 /**

--- a/client/src/models/userSettings.ts
+++ b/client/src/models/userSettings.ts
@@ -1,9 +1,11 @@
 export interface IUserSettings {
   currency: string;
+  budgetWarningThreshold: number;
 }
 
 export interface IUserSettingsUpdateRequest {
-  currency: string;
+  currency?: string;
+  budgetWarningThreshold?: number;
 }
 
 export enum Currency {

--- a/server/BudgetBoard.Database/Migrations/20250917014959_AddBudgetWarningThreshold.Designer.cs
+++ b/server/BudgetBoard.Database/Migrations/20250917014959_AddBudgetWarningThreshold.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetBoard.Database.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BudgetBoard.Database.Migrations
 {
     [DbContext(typeof(UserDataContext))]
-    partial class UserDataContextModelSnapshot : ModelSnapshot
+    [Migration("20250917014959_AddBudgetWarningThreshold")]
+    partial class AddBudgetWarningThreshold
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/BudgetBoard.Database/Migrations/20250917014959_AddBudgetWarningThreshold.cs
+++ b/server/BudgetBoard.Database/Migrations/20250917014959_AddBudgetWarningThreshold.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BudgetBoard.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBudgetWarningThreshold : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BudgetWarningThreshold",
+                table: "UserSettings",
+                type: "integer",
+                nullable: false,
+                defaultValue: 80
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "BudgetWarningThreshold", table: "UserSettings");
+        }
+    }
+}

--- a/server/BudgetBoard.Database/Models/UserSettings.cs
+++ b/server/BudgetBoard.Database/Models/UserSettings.cs
@@ -19,6 +19,7 @@ public class UserSettings()
 {
     public Guid ID { get; set; }
     public string Currency { get; set; } = "USD";
+    public int BudgetWarningThreshold { get; set; } = 80;
     public Guid UserID { get; set; }
     public ApplicationUser User { get; set; } = null!;
 }

--- a/server/BudgetBoard.Service/Models/UserSettings.cs
+++ b/server/BudgetBoard.Service/Models/UserSettings.cs
@@ -5,37 +5,44 @@ namespace BudgetBoard.Service.Models;
 
 public interface IUserSettingsResponse
 {
-    string Currency { get; set; }
+    string Currency { get; }
+    int BudgetWarningThreshold { get; }
 }
 
 public class UserSettingsResponse : IUserSettingsResponse
 {
     public string Currency { get; set; }
+    public int BudgetWarningThreshold { get; set; }
 
     [JsonConstructor]
     public UserSettingsResponse()
     {
         Currency = "USD";
+        BudgetWarningThreshold = 80;
     }
 
     public UserSettingsResponse(UserSettings userSettings)
     {
         Currency = userSettings.Currency.ToString();
+        BudgetWarningThreshold = userSettings.BudgetWarningThreshold;
     }
 }
 
 public interface IUserSettingsUpdateRequest
 {
-    public string Currency { get; set; }
+    public string? Currency { get; }
+    public int? BudgetWarningThreshold { get; }
 }
 
 public class UserSettingsUpdateRequest : IUserSettingsUpdateRequest
 {
-    public string Currency { get; set; }
+    public string? Currency { get; set; }
+    public int? BudgetWarningThreshold { get; set; }
 
     [JsonConstructor]
     public UserSettingsUpdateRequest()
     {
         Currency = "USD";
+        BudgetWarningThreshold = 80;
     }
 }

--- a/server/BudgetBoard.Service/Models/UserSettings.cs
+++ b/server/BudgetBoard.Service/Models/UserSettings.cs
@@ -42,7 +42,7 @@ public class UserSettingsUpdateRequest : IUserSettingsUpdateRequest
     [JsonConstructor]
     public UserSettingsUpdateRequest()
     {
-        Currency = "USD";
-        BudgetWarningThreshold = 80;
+        Currency = null;
+        BudgetWarningThreshold = null;
     }
 }

--- a/server/BudgetBoard.Service/UserSettingsService.cs
+++ b/server/BudgetBoard.Service/UserSettingsService.cs
@@ -47,7 +47,30 @@ public class UserSettingsService(
             throw new BudgetBoardServiceException("User settings not found.");
         }
 
-        userSettings.Currency = userSettingsUpdateRequest.Currency;
+        if (
+            userSettingsUpdateRequest.BudgetWarningThreshold < 0
+            || userSettingsUpdateRequest.BudgetWarningThreshold > 100
+        )
+        {
+            _logger.LogError(
+                "Invalid budget warning threshold value: {ThresholdValue}",
+                userSettingsUpdateRequest.BudgetWarningThreshold
+            );
+            throw new BudgetBoardServiceException(
+                "Budget warning threshold must be between 0% and 100%."
+            );
+        }
+
+        if (userSettingsUpdateRequest.Currency != null)
+        {
+            userSettings.Currency = userSettingsUpdateRequest.Currency;
+        }
+
+        if (userSettingsUpdateRequest.BudgetWarningThreshold != null)
+        {
+            userSettings.BudgetWarningThreshold = (int)
+                userSettingsUpdateRequest.BudgetWarningThreshold;
+        }
 
         await _userDataContext.SaveChangesAsync();
     }


### PR DESCRIPTION
- Changed income to be blue instead of red when below the target
- Changed expenses to have a warning level that makes the color yellow
- Warning threshold can be set in new settings dialog