### PR TITLE
Index accounts/institutions on data load

### DIFF
--- a/client/src/app/Authorized/PageContent/Accounts/AccountsContent/AccountsContent.tsx
+++ b/client/src/app/Authorized/PageContent/Accounts/AccountsContent/AccountsContent.tsx
@@ -55,8 +55,15 @@ const AccountsContent = (props: AccountsContentProps) => {
 
   React.useEffect(() => {
     if (institutionQuery.data) {
+      // Some institutions might have conflicting indices, so we need to re-index them here
+      // to ensure the drag-and-drop functionality works correctly
       setSortedInstitutions(
-        institutionQuery.data.sort((a, b) => a.index - b.index)
+        institutionQuery.data
+          .sort((a, b) => a.index - b.index)
+          .map((inst, index) => ({
+            ...inst,
+            index,
+          }))
       );
     }
   }, [institutionQuery.data]);
@@ -98,6 +105,7 @@ const AccountsContent = (props: AccountsContentProps) => {
               index,
             })
           );
+
           setSortedInstitutions(updatedList);
         }}
       >

--- a/client/src/app/Authorized/PageContent/Accounts/AccountsContent/AccountsContent.tsx
+++ b/client/src/app/Authorized/PageContent/Accounts/AccountsContent/AccountsContent.tsx
@@ -59,6 +59,7 @@ const AccountsContent = (props: AccountsContentProps) => {
       // to ensure the drag-and-drop functionality works correctly
       setSortedInstitutions(
         institutionQuery.data
+          .slice()
           .sort((a, b) => a.index - b.index)
           .map((inst, index) => ({
             ...inst,

--- a/client/src/app/Authorized/PageContent/Accounts/AccountsContent/InstitutionItem/InstitutionItem.tsx
+++ b/client/src/app/Authorized/PageContent/Accounts/AccountsContent/InstitutionItem/InstitutionItem.tsx
@@ -42,6 +42,7 @@ const InstitutionItem = (props: IInstitutionItemProps) => {
     IAccountResponse[]
   >(
     props.institution.accounts
+      .slice()
       .sort((a, b) => a.index - b.index)
       .map((a, index) => ({
         ...a,
@@ -82,6 +83,7 @@ const InstitutionItem = (props: IInstitutionItemProps) => {
   useDidUpdate(() => {
     setSortedAccounts(
       props.institution.accounts
+        .slice()
         .sort((a, b) => a.index - b.index)
         .map((a, index) => ({
           ...a,

--- a/client/src/app/Authorized/PageContent/Accounts/AccountsContent/InstitutionItem/InstitutionItem.tsx
+++ b/client/src/app/Authorized/PageContent/Accounts/AccountsContent/InstitutionItem/InstitutionItem.tsx
@@ -36,9 +36,18 @@ interface IInstitutionItemProps {
 const InstitutionItem = (props: IInstitutionItemProps) => {
   const [isSelected, { toggle }] = useDisclosure(false);
 
+  // Some accounts might have conflicting indices, so we need to re-index them here
+  // to ensure the drag-and-drop functionality works correctly
   const [sortedAccounts, setSortedAccounts] = React.useState<
     IAccountResponse[]
-  >(props.institution.accounts.sort((a, b) => a.index - b.index));
+  >(
+    props.institution.accounts
+      .sort((a, b) => a.index - b.index)
+      .map((a, index) => ({
+        ...a,
+        index,
+      }))
+  );
 
   const { ref, handleRef } = useSortable({
     id: props.institution.id,
@@ -72,7 +81,12 @@ const InstitutionItem = (props: IInstitutionItemProps) => {
 
   useDidUpdate(() => {
     setSortedAccounts(
-      props.institution.accounts.sort((a, b) => a.index - b.index)
+      props.institution.accounts
+        .sort((a, b) => a.index - b.index)
+        .map((a, index) => ({
+          ...a,
+          index,
+        }))
     );
   }, [props.institution.accounts]);
 
@@ -131,6 +145,7 @@ const InstitutionItem = (props: IInstitutionItemProps) => {
                     index,
                   })
                 );
+
                 setSortedAccounts(updatedList);
               }}
             >


### PR DESCRIPTION
- If the items don't have unique indices on load the dnd library doesn't work right
- Currently the workaround is to just reorder -> save -> then actually do your reordering
- This prevents you from having to do that first save