### PR TITLE
Add sync months override

### DIFF
--- a/client/src/app/Authorized/PageContent/Settings/AdvancedSettings/AdvancedSettings.tsx
+++ b/client/src/app/Authorized/PageContent/Settings/AdvancedSettings/AdvancedSettings.tsx
@@ -1,0 +1,17 @@
+import { Card, Stack, Text } from "@mantine/core";
+import ForceSyncLookbackPeriod from "./ForceSyncLookbackPeriod/ForceSyncLookbackPeriod";
+
+const AdvancedSettings = () => {
+  return (
+    <Card p="0.5rem" withBorder radius="md" shadow="sm">
+      <Stack gap="0.5rem">
+        <Text size="lg" fw={700}>
+          Advanced Settings
+        </Text>
+        <ForceSyncLookbackPeriod />
+      </Stack>
+    </Card>
+  );
+};
+
+export default AdvancedSettings;

--- a/client/src/app/Authorized/PageContent/Settings/AdvancedSettings/ForceSyncLookbackPeriod/ForceSyncLookbackPeriod.tsx
+++ b/client/src/app/Authorized/PageContent/Settings/AdvancedSettings/ForceSyncLookbackPeriod/ForceSyncLookbackPeriod.tsx
@@ -1,0 +1,115 @@
+import { LoadingOverlay, Select, Stack, Text } from "@mantine/core";
+import { useField } from "@mantine/form";
+import { notifications } from "@mantine/notifications";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
+import React from "react";
+import { AuthContext } from "~/components/AuthProvider/AuthProvider";
+import { translateAxiosError } from "~/helpers/requests";
+import {
+  IUserSettings,
+  IUserSettingsUpdateRequest,
+} from "~/models/userSettings";
+
+const ForceSyncLookbackPeriod = (): React.ReactNode => {
+  interface IForceSyncOverrideOption {
+    value: number;
+    label: string;
+  }
+
+  const ForceSyncOverrideOptions: IForceSyncOverrideOption[] = [
+    { value: 0, label: "Auto" },
+    { value: 1, label: "1 Month" },
+    { value: 2, label: "2 Months" },
+    { value: 3, label: "3 Months" },
+    { value: 4, label: "4 Months" },
+    { value: 5, label: "5 Months" },
+    { value: 6, label: "6 Months" },
+    { value: 7, label: "7 Months" },
+    { value: 8, label: "8 Months" },
+    { value: 9, label: "9 Months" },
+    { value: 10, label: "10 Months" },
+    { value: 11, label: "11 Months" },
+    { value: 12, label: "12 Months" },
+  ];
+
+  const { request } = React.useContext<any>(AuthContext);
+
+  const userSettingsQuery = useQuery({
+    queryKey: ["userSettings"],
+    queryFn: async (): Promise<IUserSettings | undefined> => {
+      const res: AxiosResponse = await request({
+        url: "/api/userSettings",
+        method: "GET",
+      });
+
+      if (res.status === 200) {
+        return res.data as IUserSettings;
+      }
+
+      return undefined;
+    },
+  });
+
+  const forceSyncLookbackMonthsField = useField<number>({
+    initialValue: userSettingsQuery.data?.forceSyncLookbackMonths || 0,
+  });
+
+  React.useEffect(() => {
+    if (userSettingsQuery.data?.forceSyncLookbackMonths !== undefined) {
+      forceSyncLookbackMonthsField.setValue(
+        userSettingsQuery.data.forceSyncLookbackMonths
+      );
+    }
+  }, [userSettingsQuery.data]);
+
+  const queryClient = useQueryClient();
+  const doUpdateUserSettings = useMutation({
+    mutationFn: async (updatedUserSettings: IUserSettingsUpdateRequest) =>
+      await request({
+        url: "/api/userSettings",
+        method: "PUT",
+        data: updatedUserSettings,
+      }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["userSettings"] });
+    },
+    onError: (error: any) => {
+      notifications.show({
+        color: "red",
+        message: translateAxiosError(error),
+      });
+    },
+  });
+
+  return (
+    <Stack gap="0.25rem">
+      <LoadingOverlay visible={doUpdateUserSettings.isPending} />
+      <Text size="sm" fw={600}>
+        Force Sync Lookback Period
+      </Text>
+      <Text size="xs" c="dimmed">
+        This setting can be used to override the number of months to request
+        from SimpleFIN during sync. Leave as "Auto" to let the system decide.
+      </Text>
+      <Text size="xs" c="dimmed" fw={600}>
+        Note: Leave this on auto for the best performance.
+      </Text>
+      <Select
+        data={ForceSyncOverrideOptions.map((option) => ({
+          value: option.value.toString(),
+          label: option.label,
+        }))}
+        value={forceSyncLookbackMonthsField.getValue().toString()}
+        onChange={(value) => {
+          const intValue = parseInt(value || "0", 10);
+          doUpdateUserSettings.mutate({
+            forceSyncLookbackMonths: intValue,
+          });
+        }}
+      />
+    </Stack>
+  );
+};
+
+export default ForceSyncLookbackPeriod;

--- a/client/src/app/Authorized/PageContent/Settings/Settings.tsx
+++ b/client/src/app/Authorized/PageContent/Settings/Settings.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import ResetPassword from "./ResetPassword";
 import UserSettings from "./UserSettings";
 import TwoFactorAuth from "./TwoFactorAuth";
+import AdvancedSettings from "./AdvancedSettings/AdvancedSettings";
 
 const Settings = (): React.ReactNode => {
   return (
@@ -17,6 +18,7 @@ const Settings = (): React.ReactNode => {
       <LinkSimpleFin />
       <TwoFactorAuth />
       <ResetPassword />
+      <AdvancedSettings />
     </Stack>
   );
 };

--- a/client/src/models/userSettings.ts
+++ b/client/src/models/userSettings.ts
@@ -1,11 +1,13 @@
 export interface IUserSettings {
   currency: string;
   budgetWarningThreshold: number;
+  forceSyncLookbackMonths: number;
 }
 
 export interface IUserSettingsUpdateRequest {
   currency?: string;
   budgetWarningThreshold?: number;
+  forceSyncLookbackMonths?: number;
 }
 
 export enum Currency {

--- a/server/BudgetBoard.Database/Migrations/20251003004528_AddForceSyncMonths.Designer.cs
+++ b/server/BudgetBoard.Database/Migrations/20251003004528_AddForceSyncMonths.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetBoard.Database.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BudgetBoard.Database.Migrations
 {
     [DbContext(typeof(UserDataContext))]
-    partial class UserDataContextModelSnapshot : ModelSnapshot
+    [Migration("20251003004528_AddForceSyncMonths")]
+    partial class AddForceSyncMonths
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/BudgetBoard.Database/Migrations/20251003004528_AddForceSyncMonths.cs
+++ b/server/BudgetBoard.Database/Migrations/20251003004528_AddForceSyncMonths.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BudgetBoard.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddForceSyncMonths : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ForceSyncLookbackMonths",
+                table: "UserSettings",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ForceSyncLookbackMonths",
+                table: "UserSettings");
+        }
+    }
+}

--- a/server/BudgetBoard.Database/Models/UserSettings.cs
+++ b/server/BudgetBoard.Database/Models/UserSettings.cs
@@ -20,6 +20,7 @@ public class UserSettings()
     public Guid ID { get; set; }
     public string Currency { get; set; } = "USD";
     public int BudgetWarningThreshold { get; set; } = 80;
+    public int ForceSyncLookbackMonths { get; set; } = 0;
     public Guid UserID { get; set; }
     public ApplicationUser User { get; set; } = null!;
 }

--- a/server/BudgetBoard.Service/Models/UserSettings.cs
+++ b/server/BudgetBoard.Service/Models/UserSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Runtime.InteropServices.Marshalling;
+using System.Text.Json.Serialization;
 using BudgetBoard.Database.Models;
 
 namespace BudgetBoard.Service.Models;
@@ -7,24 +8,28 @@ public interface IUserSettingsResponse
 {
     string Currency { get; }
     int BudgetWarningThreshold { get; }
+    int ForceSyncLookbackMonths { get; }
 }
 
 public class UserSettingsResponse : IUserSettingsResponse
 {
     public string Currency { get; set; }
     public int BudgetWarningThreshold { get; set; }
+    public int ForceSyncLookbackMonths { get; set; }
 
     [JsonConstructor]
     public UserSettingsResponse()
     {
         Currency = "USD";
         BudgetWarningThreshold = 80;
+        ForceSyncLookbackMonths = 0;
     }
 
     public UserSettingsResponse(UserSettings userSettings)
     {
         Currency = userSettings.Currency.ToString();
         BudgetWarningThreshold = userSettings.BudgetWarningThreshold;
+        ForceSyncLookbackMonths = userSettings.ForceSyncLookbackMonths;
     }
 }
 
@@ -32,17 +37,20 @@ public interface IUserSettingsUpdateRequest
 {
     public string? Currency { get; }
     public int? BudgetWarningThreshold { get; }
+    public int? ForceSyncLookbackMonths { get; }
 }
 
 public class UserSettingsUpdateRequest : IUserSettingsUpdateRequest
 {
     public string? Currency { get; set; }
     public int? BudgetWarningThreshold { get; set; }
+    public int? ForceSyncLookbackMonths { get; set; }
 
     [JsonConstructor]
     public UserSettingsUpdateRequest()
     {
         Currency = null;
         BudgetWarningThreshold = null;
+        ForceSyncLookbackMonths = null;
     }
 }

--- a/server/BudgetBoard.Service/UserSettingsService.cs
+++ b/server/BudgetBoard.Service/UserSettingsService.cs
@@ -72,6 +72,25 @@ public class UserSettingsService(
                 userSettingsUpdateRequest.BudgetWarningThreshold;
         }
 
+        if (userSettingsUpdateRequest.ForceSyncLookbackMonths != null)
+        {
+            if (
+                userSettingsUpdateRequest.ForceSyncLookbackMonths < 0
+                || userSettingsUpdateRequest.ForceSyncLookbackMonths > 12
+            )
+            {
+                _logger.LogError(
+                    "Invalid force sync lookback months value: {LookbackValue}",
+                    userSettingsUpdateRequest.ForceSyncLookbackMonths
+                );
+                throw new BudgetBoardServiceException(
+                    "Force sync lookback months must be between 0 and 12 months."
+                );
+            }
+            userSettings.ForceSyncLookbackMonths = (int)
+                userSettingsUpdateRequest.ForceSyncLookbackMonths;
+        }
+
         await _userDataContext.SaveChangesAsync();
     }
 


### PR DESCRIPTION
This pull request introduces a new "Force Sync Lookback Period" advanced user setting, allowing users to customize how many months of transaction history are fetched during SimpleFIN syncs. The change is implemented across both the frontend and backend, including database schema updates, API models, business logic, and UI integration.

**Backend changes:**

* **Database and model updates:** Added a new `ForceSyncLookbackMonths` field to the `UserSettings` database table and corresponding data models, with migration and snapshot updates. [[1]](diffhunk://#diff-abcb90b49de472236a3a1659216ec07fc0d8cbd481b6fb8e6d30a9c97c7dfdc3R1-R29) [[2]](diffhunk://#diff-1ea840ecccb44cdb8fd06c5c75dc3aa7d7f347d1294bb61e2aab07cf127eae95R23) [[3]](diffhunk://#diff-c2814b045dcc1b79bee539e03f78b6f18fa044545e8a0ed8f1b2915e12be92bcR4-R10) [[4]](diffhunk://#diff-5f12652f199ffd629ce7b90130b065eabff9f77a060e2c30add18dcf2b224eddR409-R411)
* **API and service logic:** Extended the user settings API models to support the new field and updated the sync logic in `SimpleFinService` to use the override value when set, including validation to ensure the value is between 0 and 12 months. Also improved handling of deleted accounts and earliest sync time calculation. [[1]](diffhunk://#diff-2c26063e556c68278d48c71692beed5711e341afe445fcb6053e82ea16d4db3dR11-R54) [[2]](diffhunk://#diff-c8719606f0183cad9d4c4f109c6ef98732db7b3246b4b9e0d2d5ff60674bbabbL84-R116) [[3]](diffhunk://#diff-c8719606f0183cad9d4c4f109c6ef98732db7b3246b4b9e0d2d5ff60674bbabbR170-R211) [[4]](diffhunk://#diff-c8719606f0183cad9d4c4f109c6ef98732db7b3246b4b9e0d2d5ff60674bbabbR358-R363) [[5]](diffhunk://#diff-8c12e654f6a94f9e026631f66b5eedce5fbbd7f6383ec78632b6651c82e0d708R75-R93)

**Frontend changes:**

* **Advanced Settings UI:** Added a new `AdvancedSettings` section to the settings page, featuring a `ForceSyncLookbackPeriod` component. This component lets users select the lookback period and updates the backend via API. [[1]](diffhunk://#diff-eebd37c6c19908abd9cf69e35a14ed4c76721c25a2bcadec3ba1ba1489abb932R1-R17) [[2]](diffhunk://#diff-d6c8fba1b28c323e112c01f8ec006e60b6c85ae2908f7b9869313522105d7eefR1-R115) [[3]](diffhunk://#diff-397fe9044845a0b70029e66f1053fe191f020bfa25356e562346e3d379304813R10) [[4]](diffhunk://#diff-397fe9044845a0b70029e66f1053fe191f020bfa25356e562346e3d379304813R21)
* **User settings model:** Updated the frontend user settings model to include the new field for seamless integration with backend changes.

These changes allow users to control sync history depth for improved performance or troubleshooting, while maintaining sensible defaults and robust validation.

**Most important changes:**

**Backend:**
- Added `ForceSyncLookbackMonths` to the `UserSettings` table, models, and migrations, enabling persistent storage of the new setting. [[1]](diffhunk://#diff-abcb90b49de472236a3a1659216ec07fc0d8cbd481b6fb8e6d30a9c97c7dfdc3R1-R29) [[2]](diffhunk://#diff-1ea840ecccb44cdb8fd06c5c75dc3aa7d7f347d1294bb61e2aab07cf127eae95R23) [[3]](diffhunk://#diff-5f12652f199ffd629ce7b90130b065eabff9f77a060e2c30add18dcf2b224eddR409-R411)
- Updated API models and validation to support the new field, including range checks (0–12 months) and integration with user settings update logic. [[1]](diffhunk://#diff-2c26063e556c68278d48c71692beed5711e341afe445fcb6053e82ea16d4db3dR11-R54) [[2]](diffhunk://#diff-8c12e654f6a94f9e026631f66b5eedce5fbbd7f6383ec78632b6651c82e0d708R75-R93)
- Enhanced SimpleFIN sync logic to honor the user’s override value, default to 12 months on first sync, and ignore deleted accounts when calculating sync history. [[1]](diffhunk://#diff-c8719606f0183cad9d4c4f109c6ef98732db7b3246b4b9e0d2d5ff60674bbabbL84-R116) [[2]](diffhunk://#diff-c8719606f0183cad9d4c4f109c6ef98732db7b3246b4b9e0d2d5ff60674bbabbR170-R211) [[3]](diffhunk://#diff-c8719606f0183cad9d4c4f109c6ef98732db7b3246b4b9e0d2d5ff60674bbabbR358-R363)

**Frontend:**
- Added `AdvancedSettings` and `ForceSyncLookbackPeriod` components to the settings page, providing a user interface for configuring the new setting. [[1]](diffhunk://#diff-eebd37c6c19908abd9cf69e35a14ed4c76721c25a2bcadec3ba1ba1489abb932R1-R17) [[2]](diffhunk://#diff-d6c8fba1b28c323e112c01f8ec006e60b6c85ae2908f7b9869313522105d7eefR1-R115) [[3]](diffhunk://#diff-397fe9044845a0b70029e66f1053fe191f020bfa25356e562346e3d379304813R10) [[4]](diffhunk://#diff-397fe9044845a0b70029e66f1053fe191f020bfa25356e562346e3d379304813R21)
- Updated frontend user settings model to include `forceSyncLookbackMonths`, ensuring compatibility with backend changes.