### PR TITLE
add some new email sender options

### DIFF
--- a/server/BudgetBoard.WebAPI/Utils/EmailSender.cs
+++ b/server/BudgetBoard.WebAPI/Utils/EmailSender.cs
@@ -48,7 +48,7 @@ public class EmailSender(IConfiguration configuration) : IEmailSender
             EnableSsl = true,
             UseDefaultCredentials = false,
             Port = smtpPort,
-            Credentials = new NetworkCredential(senderUsername ?? sender, senderPassword),
+            Credentials = new NetworkCredential(senderUsername, senderPassword),
         };
 
         await smtp.SendMailAsync(mm);


### PR DESCRIPTION
- Added an option to specify the username credential separate from the sender
  - If not included, will default to the EMAIL_SENDER option, which is required
- Added an option to specify the port