### PR TITLE
add build tag for non-release builds

### DIFF
--- a/.github/workflows/docker-image-ci-build.yml
+++ b/.github/workflows/docker-image-ci-build.yml
@@ -78,14 +78,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Create .env File
+      - name: Create .env File (release)
+        run: echo "VITE_VERSION=PLACEHOLDER" >> client/.env
+        if: github.event_name == 'release'
+
+      - name: Create .env File (non-release)
         run: echo "VITE_VERSION=sha-${GITHUB_SHA::7}" >> client/.env
+        if: github.event_name != 'release'
 
       - name: Write Version to File
         uses: eball/write-tag-to-version-file@latest
         with:
           filename: "client/.env"
-          placeholder: "sha-${GITHUB_SHA::7}"
+          placeholder: "PLACEHOLDER"
         if: github.event_name == 'release'
 
       - name: Log in to the Container registry


### PR DESCRIPTION
Currently, non-release builds have no version displayed on the dashboard. Updating so the sha now shows for some sort of version reference.