### PR TITLE
Filtering deleted and uncategorized transactions before training the auto categorizer

### DIFF
--- a/server/BudgetBoard.Service/AutomaticTransactionCategorizerService.cs
+++ b/server/BudgetBoard.Service/AutomaticTransactionCategorizerService.cs
@@ -29,7 +29,11 @@ public class AutomaticTransactionCategorizerService(
             throw new BudgetBoardServiceException(responseLocalizer["UserSettingsNotFoundError"]);
         }
 
-        var trainingTransactions = userData.Accounts.Select(a => a.Transactions).SelectMany(c => c);
+        var trainingTransactions = userData.Accounts
+            .Where(a => a.Deleted is null) // Filter out deleted accounts
+            .Select(a => a.Transactions)
+            .SelectMany(c => c)
+            .Where(t => t.Deleted is null && t.Category is not null && !t.Category.Equals(string.Empty)); // Filter out deleted transactions or those without category
         if (request.StartDate is not null)
         {
             trainingTransactions = trainingTransactions.Where(t =>


### PR DESCRIPTION
Filtering out deleted accounts/transactions and uncategorized transactions before training the model. If you think they should be used anyways, or that there should be a switch to control whether they're used or not, let me know. But I feel like this should be the expected behaviour.