### PR TITLE
Coerce net worth categories to lowercase

### DIFF
--- a/client/src/app/Authorized/PageContent/Dashboard/NetWorthCard/NetWorthCardSettings/NetWorthGroupItem/NetWorthLineItem/NetWorthLineCategory/EditableNetWorthLineCategoryContent/EditableNetWorthLineCategoryContent.tsx
+++ b/client/src/app/Authorized/PageContent/Dashboard/NetWorthCard/NetWorthCardSettings/NetWorthGroupItem/NetWorthLineItem/NetWorthLineCategory/EditableNetWorthLineCategoryContent/EditableNetWorthLineCategoryContent.tsx
@@ -30,13 +30,14 @@ interface EditableNetWorthLineCategoryContentProps {
 }
 
 const EditableNetWorthLineCategoryContent = (
-  props: EditableNetWorthLineCategoryContentProps
+  props: EditableNetWorthLineCategoryContentProps,
 ): React.ReactNode => {
+  // These two need to be coerced to lowercase because pre-localization these were stored with a capitalized first letter.
   const typeField = useField<string | null>({
-    initialValue: props.category.type,
+    initialValue: props.category.type.toLowerCase(),
   });
   const subtypeField = useField<string | null>({
-    initialValue: props.category.subtype,
+    initialValue: props.category.subtype.toLowerCase(),
   });
   const valueField = useField<string | null>({
     initialValue: props.category.value,
@@ -191,7 +192,7 @@ const EditableNetWorthLineCategoryContent = (
       .filter(
         (name) =>
           !areStringsEqual(name, props.currentLineName) &&
-          !wouldCreateCircularDependency(name)
+          !wouldCreateCircularDependency(name),
       );
 
     return [...new Set(validLineNames)];
@@ -199,7 +200,7 @@ const EditableNetWorthLineCategoryContent = (
 
   const getValidNetWorthValuesForTypeAndSubtype = (
     type: string,
-    subtype: string
+    subtype: string,
   ): React.ReactNode => {
     if (areStringsEqual(type, "account")) {
       if (areStringsEqual(subtype, "category")) {
@@ -241,7 +242,7 @@ const EditableNetWorthLineCategoryContent = (
           w="100px"
           size="xs"
           data={NET_WORTH_CATEGORY_TYPES.map((i) => ({
-            ...i,
+            value: i.value,
             label: t(i.label),
           }))}
           {...typeField.getInputProps()}
@@ -252,7 +253,7 @@ const EditableNetWorthLineCategoryContent = (
           w="100px"
           size="xs"
           data={getSubtypeOptions(typeField.getValue() ?? "").map((i) => ({
-            ...i,
+            value: i.value,
             label: t(i.label),
           }))}
           {...subtypeField.getInputProps()}
@@ -265,7 +266,7 @@ const EditableNetWorthLineCategoryContent = (
       <Group gap="0.25rem">
         {getValidNetWorthValuesForTypeAndSubtype(
           typeField.getValue() ?? "",
-          subtypeField.getValue() ?? ""
+          subtypeField.getValue() ?? "",
         )}
         <Flex style={{ alignSelf: "stretch" }}>
           <ActionIcon

--- a/client/src/app/Authorized/PageContent/Dashboard/NetWorthCard/NetWorthCardSettings/NetWorthGroupItem/NetWorthLineItem/NetWorthLineCategory/NetWorthLineCategoryContent/NetWorthLineCategoryContent.tsx
+++ b/client/src/app/Authorized/PageContent/Dashboard/NetWorthCard/NetWorthCardSettings/NetWorthGroupItem/NetWorthLineItem/NetWorthLineCategory/NetWorthLineCategoryContent/NetWorthLineCategoryContent.tsx
@@ -12,21 +12,23 @@ interface NetWorthLineCategoryContentProps {
 }
 
 const NetWorthLineCategoryContent = (
-  props: NetWorthLineCategoryContentProps
+  props: NetWorthLineCategoryContentProps,
 ) => {
   const { t } = useTranslation();
 
   const getTypeDisplayString = (): string => {
+    // This needs to be coerced to lowercase because pre-localization these were stored with a capitalized first letter.
     const type = NET_WORTH_CATEGORY_TYPES.find(
-      (type) => type.value === props.category.type
+      (type) => type.value === props.category.type.toLowerCase(),
     );
     return type ? t(type.label) : props.category.type;
   };
 
   const getSubtypeDisplayString = (): string => {
+    // This needs to be coerced to lowercase because pre-localization these were stored with a capitalized first letter.
     const subtypeOptions = getSubtypeOptions(props.category.type);
     const subtype = subtypeOptions.find(
-      (subtype) => subtype.value === props.category.subtype
+      (subtype) => subtype.value === props.category.subtype.toLowerCase(),
     );
     return subtype ? t(subtype.label) : props.category.subtype;
   };


### PR DESCRIPTION
Before localization, these values had a capital letter. Need to coerce them to lower case to work with the localization.