### PR TITLE
update compose to set postgres timezone

### DIFF
--- a/compose.env
+++ b/compose.env
@@ -1,5 +1,8 @@
 # See https://budgetboard.net/deploy/configuration for details about each setting.
 
+# Common configuration
+TZ=UTC
+
 # Client configuration
 PORT=6253
 

--- a/compose.yml
+++ b/compose.yml
@@ -55,6 +55,7 @@ services:
     container_name: postgres-db
     image: postgres:16
     restart: unless-stopped
+    command: ["-c", "timezone=${TZ:-UTC}"]
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-superSecretPassword}


### PR DESCRIPTION
Postgres timezone is needed to properly migrate from DateTime to DateOnly.