### PR TITLE
Catch sync exceptions

### DIFF
--- a/server/BudgetBoard.Service/LunchFlowService.cs
+++ b/server/BudgetBoard.Service/LunchFlowService.cs
@@ -383,36 +383,54 @@ public class LunchFlowService(
                 continue;
             }
 
-            List<Transaction> userTransactions =
-            [
-                .. userAccount.Transactions.OrderByDescending(t => t.Date),
-            ];
-
-            // SyncStartDate allows the user to specify a date from which to start syncing transactions.
-            // If it is unset, all transactions will be synced.
-            var transactionsToSync = lunchFlowTransactionsData.Transactions.Where(t =>
-                !lunchFlowAccount.SyncStartDate.HasValue
-                || DateOnly.Parse(t.Date) >= lunchFlowAccount.SyncStartDate.Value
-            );
-
-            foreach (var transaction in transactionsToSync)
+            try
             {
-                if (userTransactions.Any(t => t.SyncID != null && t.SyncID == transaction.ID))
-                {
-                    continue;
-                }
+                List<Transaction> userTransactions =
+                [
+                    .. userAccount.Transactions.OrderByDescending(t => t.Date),
+                ];
 
-                await transactionService.CreateTransactionAsync(
-                    userData.Id,
-                    new TransactionCreateRequest
+                // SyncStartDate allows the user to specify a date from which to start syncing transactions.
+                // If it is unset, all transactions will be synced.
+                var transactionsToSync = lunchFlowTransactionsData.Transactions.Where(t =>
+                    !lunchFlowAccount.SyncStartDate.HasValue
+                    || DateOnly.Parse(t.Date) >= lunchFlowAccount.SyncStartDate.Value
+                );
+
+                foreach (var transaction in transactionsToSync)
+                {
+                    if (userTransactions.Any(t => t.SyncID != null && t.SyncID == transaction.ID))
                     {
-                        AccountID = userAccount.ID,
-                        SyncID = transaction.ID,
-                        Amount = transaction.Amount,
-                        Date = DateOnly.Parse(transaction.Date),
-                        MerchantName = transaction.Merchant,
-                        Source = TransactionSource.LunchFlow.Value,
+                        continue;
                     }
+
+                    await transactionService.CreateTransactionAsync(
+                        userData.Id,
+                        new TransactionCreateRequest
+                        {
+                            AccountID = userAccount.ID,
+                            SyncID = transaction.ID,
+                            Amount = transaction.Amount,
+                            Date = DateOnly.Parse(transaction.Date),
+                            MerchantName = transaction.Merchant,
+                            Source = TransactionSource.LunchFlow.Value,
+                        }
+                    );
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "{LogMessage}",
+                    logLocalizer[
+                        "LunchFlowAccountSyncExceptionLog",
+                        lunchFlowAccount.SyncID,
+                        ex.Message
+                    ]
+                );
+                errors.Add(
+                    responseLocalizer["LunchFlowAccountSyncException", lunchFlowAccount.SyncID]
                 );
             }
         }
@@ -488,19 +506,39 @@ public class LunchFlowService(
                 continue;
             }
 
-            var error = await SyncHelpers.SyncBalance(
-                userData,
-                new BalanceCreateRequest
-                {
-                    AccountID = lunchFlowAccount.LinkedAccountId!.Value,
-                    Amount = lunchFlowBalancesData.Balance.Amount,
-                    Date = DateOnly.FromDateTime(nowProvider.Now),
-                },
-                balanceService
-            );
-            if (error.HasValue)
+            try
             {
-                errors.Add(responseLocalizer[error.Value.ErrorKey, [.. error.Value.ErrorParams]]);
+                var error = await SyncHelpers.SyncBalance(
+                    userData,
+                    new BalanceCreateRequest
+                    {
+                        AccountID = lunchFlowAccount.LinkedAccountId!.Value,
+                        Amount = lunchFlowBalancesData.Balance.Amount,
+                        Date = DateOnly.FromDateTime(nowProvider.Now),
+                    },
+                    balanceService
+                );
+                if (error.HasValue)
+                {
+                    errors.Add(
+                        responseLocalizer[error.Value.ErrorKey, [.. error.Value.ErrorParams]]
+                    );
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "{LogMessage}",
+                    logLocalizer[
+                        "LunchFlowAccountSyncExceptionLog",
+                        lunchFlowAccount.SyncID,
+                        ex.Message
+                    ]
+                );
+                errors.Add(
+                    responseLocalizer["LunchFlowAccountSyncException", lunchFlowAccount.SyncID]
+                );
             }
         }
 

--- a/server/BudgetBoard.Service/LunchFlowService.cs
+++ b/server/BudgetBoard.Service/LunchFlowService.cs
@@ -340,51 +340,51 @@ public class LunchFlowService(
         var lunchFlowAccounts = userData.LunchFlowAccounts.Where(a => a.LinkedAccountId != null);
         foreach (var lunchFlowAccount in lunchFlowAccounts)
         {
-            var lunchFlowTransactionsData = await GetLunchFlowTransactionsDataAsync(
-                userData.LunchFlowApiKey,
-                lunchFlowAccount.SyncID
-            );
-            if (lunchFlowTransactionsData == null)
-            {
-                logger.LogError(
-                    "{LogMessage}",
-                    logLocalizer[
-                        "LunchFlowTransactionDataRetrievalErrorLog",
-                        lunchFlowAccount.SyncID
-                    ]
-                );
-                errors.Add(
-                    responseLocalizer[
-                        "LunchFlowTransactionDataRetrievalError",
-                        lunchFlowAccount.SyncID
-                    ]
-                );
-                continue;
-            }
-
-            var userAccount = userData.Accounts.FirstOrDefault(a =>
-                a.ID == lunchFlowAccount.LinkedAccountId
-            );
-            if (userAccount == null)
-            {
-                logger.LogError(
-                    "{LogMessage}",
-                    logLocalizer[
-                        "LunchFlowLinkedAccountNotFoundForSyncErrorLog",
-                        lunchFlowAccount.SyncID
-                    ]
-                );
-                errors.Add(
-                    responseLocalizer[
-                        "LunchFlowLinkedAccountNotFoundForSyncError",
-                        lunchFlowAccount.SyncID
-                    ]
-                );
-                continue;
-            }
-
             try
             {
+                var lunchFlowTransactionsData = await GetLunchFlowTransactionsDataAsync(
+                    userData.LunchFlowApiKey,
+                    lunchFlowAccount.SyncID
+                );
+                if (lunchFlowTransactionsData == null)
+                {
+                    logger.LogError(
+                        "{LogMessage}",
+                        logLocalizer[
+                            "LunchFlowTransactionDataRetrievalErrorLog",
+                            lunchFlowAccount.SyncID
+                        ]
+                    );
+                    errors.Add(
+                        responseLocalizer[
+                            "LunchFlowTransactionDataRetrievalError",
+                            lunchFlowAccount.SyncID
+                        ]
+                    );
+                    continue;
+                }
+
+                var userAccount = userData.Accounts.FirstOrDefault(a =>
+                    a.ID == lunchFlowAccount.LinkedAccountId
+                );
+                if (userAccount == null)
+                {
+                    logger.LogError(
+                        "{LogMessage}",
+                        logLocalizer[
+                            "LunchFlowLinkedAccountNotFoundForSyncErrorLog",
+                            lunchFlowAccount.SyncID
+                        ]
+                    );
+                    errors.Add(
+                        responseLocalizer[
+                            "LunchFlowLinkedAccountNotFoundForSyncError",
+                            lunchFlowAccount.SyncID
+                        ]
+                    );
+                    continue;
+                }
+
                 List<Transaction> userTransactions =
                 [
                     .. userAccount.Transactions.OrderByDescending(t => t.Date),
@@ -490,24 +490,30 @@ public class LunchFlowService(
         var lunchFlowAccounts = userData.LunchFlowAccounts.Where(a => a.LinkedAccountId != null);
         foreach (var lunchFlowAccount in lunchFlowAccounts)
         {
-            var lunchFlowBalancesData = await GetLunchFlowBalancesDataAsync(
-                userData.LunchFlowApiKey,
-                lunchFlowAccount.SyncID
-            );
-            if (lunchFlowBalancesData == null || lunchFlowBalancesData.Balance == null)
-            {
-                logger.LogError(
-                    "{LogMessage}",
-                    logLocalizer["LunchFlowBalanceDataRetrievalErrorLog", lunchFlowAccount.SyncID]
-                );
-                errors.Add(
-                    responseLocalizer["LunchFlowBalanceDataRetrievalError", lunchFlowAccount.SyncID]
-                );
-                continue;
-            }
-
             try
             {
+                var lunchFlowBalancesData = await GetLunchFlowBalancesDataAsync(
+                    userData.LunchFlowApiKey,
+                    lunchFlowAccount.SyncID
+                );
+                if (lunchFlowBalancesData == null || lunchFlowBalancesData.Balance == null)
+                {
+                    logger.LogError(
+                        "{LogMessage}",
+                        logLocalizer[
+                            "LunchFlowBalanceDataRetrievalErrorLog",
+                            lunchFlowAccount.SyncID
+                        ]
+                    );
+                    errors.Add(
+                        responseLocalizer[
+                            "LunchFlowBalanceDataRetrievalError",
+                            lunchFlowAccount.SyncID
+                        ]
+                    );
+                    continue;
+                }
+
                 var error = await SyncHelpers.SyncBalance(
                     userData,
                     new BalanceCreateRequest

--- a/server/BudgetBoard.Service/Resources/LogStrings.resx
+++ b/server/BudgetBoard.Service/Resources/LogStrings.resx
@@ -466,6 +466,9 @@
   <data name="SimpleFinAccountNotFoundForSyncLog" xml:space="preserve">
     <value>SimpleFIN account with SyncID {0} not found in cache. Skipping account sync.</value>
   </data>
+  <data name="SimpleFinAccountSyncExceptionLog" xml:space="preserve">
+    <value>An unexpected error occurred while syncing SimpleFIN account {0}: {1}. Skipping.</value>
+  </data>
   <data name="SimpleFinAccountNotLinkedLog" xml:space="preserve">
     <value>SimpleFIN account {0} is not linked to any account. Skipping transaction sync.</value>
   </data>
@@ -507,5 +510,8 @@
   </data>
   <data name="LunchFlowBalanceDataRetrievalErrorLog" xml:space="preserve">
     <value>Failed to retrieve balance data for LunchFlow account {0}.</value>
+  </data>
+  <data name="LunchFlowAccountSyncExceptionLog" xml:space="preserve">
+    <value>An unexpected error occurred while syncing LunchFlow account {0}: {1}. Skipping.</value>
   </data>
 </root>

--- a/server/BudgetBoard.Service/Resources/ResponseStrings.resx
+++ b/server/BudgetBoard.Service/Resources/ResponseStrings.resx
@@ -457,6 +457,9 @@
   <data name="SimpleFinAccountNotFoundForSyncError" xml:space="preserve">
     <value>SimpleFIN account with SyncID '{0}' not found in cache. Skipping account sync.</value>
   </data>
+  <data name="SimpleFinAccountSyncException" xml:space="preserve">
+    <value>An unexpected error occurred while syncing SimpleFIN account '{0}'.</value>
+  </data>
   <data name="AutoCategorizerTrainingNoTransactions" xml:space="preserve">
     <value>No transactions in the range selected to train the Auto-Categorizer.</value>
   </data>
@@ -486,5 +489,8 @@
   </data>
   <data name="LunchFlowBalanceDataRetrievalError" xml:space="preserve">
     <value>Failed to retrieve balance data for LunchFlow account {0}.</value>
+  </data>
+  <data name="LunchFlowAccountSyncException" xml:space="preserve">
+    <value>An unexpected error occurred while syncing LunchFlow account '{0}'.</value>
   </data>
   </root>

--- a/server/BudgetBoard.Service/SimpleFinService.cs
+++ b/server/BudgetBoard.Service/SimpleFinService.cs
@@ -590,25 +590,37 @@ public class SimpleFinService(
                 continue;
             }
 
-            var transactionErrors = await SyncTransactionsAsync(
-                userData,
-                simpleFinAccount,
-                accountData.Transactions,
-                allCategories,
-                autoCategorizer
-            );
-            errors.AddRange(transactionErrors);
-
-            var balanceSyncErrors = await SyncBalancesAsync(
-                userData,
-                simpleFinAccount.ID,
-                accountData
-            );
-            errors.AddRange(balanceSyncErrors);
-
-            if (transactionErrors.Count == 0 && balanceSyncErrors.Count == 0)
+            try
             {
-                simpleFinAccount.LastSync = nowProvider.UtcNow;
+                var transactionErrors = await SyncTransactionsAsync(
+                    userData,
+                    simpleFinAccount,
+                    accountData.Transactions,
+                    allCategories,
+                    autoCategorizer
+                );
+                errors.AddRange(transactionErrors);
+
+                var balanceSyncErrors = await SyncBalancesAsync(
+                    userData,
+                    simpleFinAccount.ID,
+                    accountData
+                );
+                errors.AddRange(balanceSyncErrors);
+
+                if (transactionErrors.Count == 0 && balanceSyncErrors.Count == 0)
+                {
+                    simpleFinAccount.LastSync = nowProvider.UtcNow;
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "{LogMessage}",
+                    logLocalizer["SimpleFinAccountSyncExceptionLog", accountData.Name, ex.Message]
+                );
+                errors.Add(responseLocalizer["SimpleFinAccountSyncException", accountData.Name]);
             }
         }
 

--- a/server/BudgetBoard.Service/SimpleFinService.cs
+++ b/server/BudgetBoard.Service/SimpleFinService.cs
@@ -432,101 +432,119 @@ public class SimpleFinService(
 
         foreach (var simpleFinAccount in simpleFinAccounts)
         {
-            var existingOrganization = userData.SimpleFinOrganizations.SingleOrDefault(o =>
-                o.Domain == simpleFinAccount.Org.Domain
-            );
-            if (existingOrganization == null)
+            try
             {
-                var simpleFinOrganization = simpleFinAccount.Org;
-                await simpleFinOrganizationService.CreateSimpleFinOrganizationAsync(
-                    userData.Id,
-                    new SimpleFinOrganizationCreateRequest
-                    {
-                        Domain = simpleFinOrganization.Domain,
-                        SimpleFinUrl = simpleFinOrganization.SimpleFinUrl,
-                        Name = simpleFinOrganization.Name,
-                        Url = simpleFinOrganization.Url,
-                        SyncID = simpleFinOrganization.SyncID,
-                    }
-                );
-
-                existingOrganization = userData.SimpleFinOrganizations.SingleOrDefault(o =>
+                var existingOrganization = userData.SimpleFinOrganizations.SingleOrDefault(o =>
                     o.Domain == simpleFinAccount.Org.Domain
                 );
                 if (existingOrganization == null)
                 {
-                    logger.LogError(
-                        "{LogMessage}",
-                        logLocalizer[
-                            "SyncSimpleFinOrganizationCreationErrorLog",
-                            simpleFinAccount.Name
-                        ]
+                    var simpleFinOrganization = simpleFinAccount.Org;
+                    await simpleFinOrganizationService.CreateSimpleFinOrganizationAsync(
+                        userData.Id,
+                        new SimpleFinOrganizationCreateRequest
+                        {
+                            Domain = simpleFinOrganization.Domain,
+                            SimpleFinUrl = simpleFinOrganization.SimpleFinUrl,
+                            Name = simpleFinOrganization.Name,
+                            Url = simpleFinOrganization.Url,
+                            SyncID = simpleFinOrganization.SyncID,
+                        }
                     );
-                    errors.Add(
-                        responseLocalizer[
-                            "SyncSimpleFinOrganizationCreationError",
-                            simpleFinAccount.Name
-                        ]
+
+                    existingOrganization = userData.SimpleFinOrganizations.SingleOrDefault(o =>
+                        o.Domain == simpleFinAccount.Org.Domain
                     );
-                    continue;
+                    if (existingOrganization == null)
+                    {
+                        logger.LogError(
+                            "{LogMessage}",
+                            logLocalizer[
+                                "SyncSimpleFinOrganizationCreationErrorLog",
+                                simpleFinAccount.Name
+                            ]
+                        );
+                        errors.Add(
+                            responseLocalizer[
+                                "SyncSimpleFinOrganizationCreationError",
+                                simpleFinAccount.Name
+                            ]
+                        );
+                        continue;
+                    }
+                }
+                else
+                {
+                    await simpleFinOrganizationService.UpdateSimpleFinOrganizationAsync(
+                        userData.Id,
+                        new SimpleFinOrganizationUpdateRequest
+                        {
+                            ID = existingOrganization.ID,
+                            Domain = simpleFinAccount.Org.Domain,
+                            SimpleFinUrl = simpleFinAccount.Org.SimpleFinUrl,
+                            Name = simpleFinAccount.Org.Name,
+                            Url = simpleFinAccount.Org.Url,
+                        }
+                    );
+                }
+
+                var existingAccount = userData.SimpleFinAccounts.SingleOrDefault(a =>
+                    a.SyncID == simpleFinAccount.Id
+                    && a.Organization?.Domain == simpleFinAccount.Org.Domain
+                );
+                if (existingAccount == null)
+                {
+                    await simpleFinAccountService.CreateSimpleFinAccountAsync(
+                        userData.Id,
+                        new SimpleFinAccountCreateRequest
+                        {
+                            SyncID = simpleFinAccount.Id,
+                            Name = simpleFinAccount.Name,
+                            Currency = simpleFinAccount.Currency,
+                            Balance = decimal.Parse(
+                                simpleFinAccount.Balance,
+                                CultureInfo.InvariantCulture.NumberFormat
+                            ),
+                            BalanceDate = simpleFinAccount.BalanceDate,
+                            OrganizationId = existingOrganization.ID,
+                        }
+                    );
+                }
+                else
+                {
+                    await simpleFinAccountService.UpdateSimpleFinAccountAsync(
+                        userData.Id,
+                        new SimpleFinAccountUpdateRequest
+                        {
+                            ID = existingAccount.ID,
+                            SyncID = simpleFinAccount.Id,
+                            Name = simpleFinAccount.Name,
+                            Currency = simpleFinAccount.Currency,
+                            Balance = decimal.Parse(
+                                simpleFinAccount.Balance,
+                                CultureInfo.InvariantCulture.NumberFormat
+                            ),
+                            BalanceDate = DateTimeOffset
+                                .FromUnixTimeSeconds(simpleFinAccount.BalanceDate)
+                                .UtcDateTime,
+                            LastSync = existingAccount.LastSync,
+                        }
+                    );
                 }
             }
-            else
+            catch (Exception ex)
             {
-                await simpleFinOrganizationService.UpdateSimpleFinOrganizationAsync(
-                    userData.Id,
-                    new SimpleFinOrganizationUpdateRequest
-                    {
-                        ID = existingOrganization.ID,
-                        Domain = simpleFinAccount.Org.Domain,
-                        SimpleFinUrl = simpleFinAccount.Org.SimpleFinUrl,
-                        Name = simpleFinAccount.Org.Name,
-                        Url = simpleFinAccount.Org.Url,
-                    }
+                logger.LogError(
+                    ex,
+                    "{LogMessage}",
+                    logLocalizer[
+                        "SimpleFinAccountSyncExceptionLog",
+                        simpleFinAccount.Name,
+                        ex.Message
+                    ]
                 );
-            }
-
-            var existingAccount = userData.SimpleFinAccounts.SingleOrDefault(a =>
-                a.SyncID == simpleFinAccount.Id
-                && a.Organization?.Domain == simpleFinAccount.Org.Domain
-            );
-            if (existingAccount == null)
-            {
-                await simpleFinAccountService.CreateSimpleFinAccountAsync(
-                    userData.Id,
-                    new SimpleFinAccountCreateRequest
-                    {
-                        SyncID = simpleFinAccount.Id,
-                        Name = simpleFinAccount.Name,
-                        Currency = simpleFinAccount.Currency,
-                        Balance = decimal.Parse(
-                            simpleFinAccount.Balance,
-                            CultureInfo.InvariantCulture.NumberFormat
-                        ),
-                        BalanceDate = simpleFinAccount.BalanceDate,
-                        OrganizationId = existingOrganization.ID,
-                    }
-                );
-            }
-            else
-            {
-                await simpleFinAccountService.UpdateSimpleFinAccountAsync(
-                    userData.Id,
-                    new SimpleFinAccountUpdateRequest
-                    {
-                        ID = existingAccount.ID,
-                        SyncID = simpleFinAccount.Id,
-                        Name = simpleFinAccount.Name,
-                        Currency = simpleFinAccount.Currency,
-                        Balance = decimal.Parse(
-                            simpleFinAccount.Balance,
-                            CultureInfo.InvariantCulture.NumberFormat
-                        ),
-                        BalanceDate = DateTimeOffset
-                            .FromUnixTimeSeconds(simpleFinAccount.BalanceDate)
-                            .UtcDateTime,
-                        LastSync = existingAccount.LastSync,
-                    }
+                errors.Add(
+                    responseLocalizer["SimpleFinAccountSyncException", simpleFinAccount.Name]
                 );
             }
         }

--- a/server/BudgetBoard.Tests/LunchFlowServiceTests.cs
+++ b/server/BudgetBoard.Tests/LunchFlowServiceTests.cs
@@ -1344,6 +1344,6 @@ public class LunchFlowServiceTests
 
         // Assert: an error was reported for the bad account
         errors.Should().NotBeEmpty();
-        errors.Should().Contain(e => e.Contains("bad-account-id"));
+        errors.Should().Contain(e => e.Contains("LunchFlowAccountSyncException"));
     }
 }

--- a/server/BudgetBoard.Tests/LunchFlowServiceTests.cs
+++ b/server/BudgetBoard.Tests/LunchFlowServiceTests.cs
@@ -1195,16 +1195,12 @@ public class LunchFlowServiceTests
     public async Task SyncTransactionHistoryAsync_WhenOneAccountThrowsDuringSync_ShouldSyncRemainingAccounts()
     {
         // Arrange
-        // Regression test: an exception for one account must not abort sync for
-        // subsequent accounts. We simulate this by giving the first account a
-        // transaction with an unparseable date, which causes DateOnly.Parse to throw.
         var helper = new TestHelper();
         helper.demoUser.LunchFlowApiKey = "valid-api-key";
 
         var lunchFlowAccountFaker = new LunchFlowAccountFaker(helper.demoUser.Id);
 
-        // First account: transaction with a bad date → DateOnly.Parse throws
-        var accountBad = new Database.Models.Account
+        var accountBad = new Account
         {
             Name = "Bad Account",
             Type = "checking",
@@ -1218,8 +1214,7 @@ public class LunchFlowServiceTests
         lunchFlowAccountBad.SyncID = "bad-account-id";
         helper.UserDataContext.LunchFlowAccounts.Add(lunchFlowAccountBad);
 
-        // Second account: valid transaction that should still be synced
-        var accountValid = new Database.Models.Account
+        var accountValid = new Account
         {
             Name = "Valid Account",
             Type = "checking",

--- a/server/BudgetBoard.Tests/LunchFlowServiceTests.cs
+++ b/server/BudgetBoard.Tests/LunchFlowServiceTests.cs
@@ -1190,4 +1190,165 @@ public class LunchFlowServiceTests
         // Assert
         errors.Should().NotBeEmpty();
     }
+
+    [Fact]
+    public async Task SyncTransactionHistoryAsync_WhenOneAccountThrowsDuringSync_ShouldSyncRemainingAccounts()
+    {
+        // Arrange
+        // Regression test: an exception for one account must not abort sync for
+        // subsequent accounts. We simulate this by giving the first account a
+        // transaction with an unparseable date, which causes DateOnly.Parse to throw.
+        var helper = new TestHelper();
+        helper.demoUser.LunchFlowApiKey = "valid-api-key";
+
+        var lunchFlowAccountFaker = new LunchFlowAccountFaker(helper.demoUser.Id);
+
+        // First account: transaction with a bad date → DateOnly.Parse throws
+        var accountBad = new Database.Models.Account
+        {
+            Name = "Bad Account",
+            Type = "checking",
+            Subtype = "checking",
+            UserID = helper.demoUser.Id,
+        };
+        helper.UserDataContext.Accounts.Add(accountBad);
+
+        var lunchFlowAccountBad = lunchFlowAccountFaker.Generate();
+        lunchFlowAccountBad.LinkedAccountId = accountBad.ID;
+        lunchFlowAccountBad.SyncID = "bad-account-id";
+        helper.UserDataContext.LunchFlowAccounts.Add(lunchFlowAccountBad);
+
+        // Second account: valid transaction that should still be synced
+        var accountValid = new Database.Models.Account
+        {
+            Name = "Valid Account",
+            Type = "checking",
+            Subtype = "checking",
+            UserID = helper.demoUser.Id,
+        };
+        helper.UserDataContext.Accounts.Add(accountValid);
+
+        var lunchFlowAccountValid = lunchFlowAccountFaker.Generate();
+        lunchFlowAccountValid.LinkedAccountId = accountValid.ID;
+        lunchFlowAccountValid.SyncID = "valid-account-id";
+        helper.UserDataContext.LunchFlowAccounts.Add(lunchFlowAccountValid);
+
+        await helper.UserDataContext.SaveChangesAsync();
+
+        var badTransactionsResponse =
+            @"{
+                ""transactions"": [
+                    {
+                        ""id"": ""txn-bad"",
+                        ""account_id"": ""bad-account-id"",
+                        ""amount"": -20.00,
+                        ""currency"": ""USD"",
+                        ""date"": ""not-a-date"",
+                        ""merchant"": ""Broken Bank"",
+                        ""description"": ""Bad"",
+                        ""is_pending"": false
+                    }
+                ],
+                ""total"": 1
+            }";
+
+        var validTransactionsResponse =
+            @"{
+                ""transactions"": [
+                    {
+                        ""id"": ""txn-valid"",
+                        ""account_id"": ""valid-account-id"",
+                        ""amount"": -50.00,
+                        ""currency"": ""USD"",
+                        ""date"": ""2024-01-15"",
+                        ""merchant"": ""Good Store"",
+                        ""description"": ""Purchase"",
+                        ""is_pending"": false
+                    }
+                ],
+                ""total"": 1
+            }";
+
+        var balanceResponse =
+            @"{
+                ""balance"": {
+                    ""amount"": 1000.00,
+                    ""currency"": ""USD""
+                }
+            }";
+
+        var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(
+                (HttpRequestMessage request, CancellationToken token) =>
+                {
+                    var url = request.RequestUri!.ToString();
+                    if (url.Contains("/transactions"))
+                    {
+                        var body = url.Contains("bad-account-id")
+                            ? badTransactionsResponse
+                            : validTransactionsResponse;
+                        return new HttpResponseMessage
+                        {
+                            StatusCode = System.Net.HttpStatusCode.OK,
+                            Content = new StringContent(body),
+                        };
+                    }
+                    return new HttpResponseMessage
+                    {
+                        StatusCode = System.Net.HttpStatusCode.OK,
+                        Content = new StringContent(balanceResponse),
+                    };
+                }
+            );
+
+        using var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        httpClientFactoryMock
+            .Setup(_ => _.CreateClient(string.Empty))
+            .Returns(httpClient)
+            .Verifiable();
+
+        var nowProviderMock = Mock.Of<INowProvider>();
+        Mock.Get(nowProviderMock).Setup(_ => _.UtcNow).Returns(DateTime.UtcNow);
+        Mock.Get(nowProviderMock).Setup(_ => _.Now).Returns(DateTime.Now);
+
+        var transactionServiceMock = new Mock<ITransactionService>();
+
+        var lunchFlowService = new LunchFlowService(
+            httpClientFactoryMock.Object,
+            helper.UserDataContext,
+            Mock.Of<ILogger<ILunchFlowService>>(),
+            nowProviderMock,
+            Mock.Of<IAccountService>(),
+            transactionServiceMock.Object,
+            Mock.Of<IBalanceService>(),
+            Mock.Of<ILunchFlowAccountService>(),
+            TestHelper.CreateMockLocalizer<ResponseStrings>(),
+            TestHelper.CreateMockLocalizer<LogStrings>()
+        );
+
+        // Act
+        var errors = await lunchFlowService.SyncTransactionHistoryAsync(helper.demoUser.Id);
+
+        // Assert: the valid account's transaction was still created
+        transactionServiceMock.Verify(
+            _ =>
+                _.CreateTransactionAsync(
+                    helper.demoUser.Id,
+                    It.Is<ITransactionCreateRequest>(r => r.SyncID == "txn-valid")
+                ),
+            Times.Once
+        );
+
+        // Assert: an error was reported for the bad account
+        errors.Should().NotBeEmpty();
+        errors.Should().Contain(e => e.Contains("bad-account-id"));
+    }
 }

--- a/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
+++ b/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
@@ -884,6 +884,144 @@ public class SimpleFinServiceTests
     }
 
     [Fact]
+    public async Task RefreshAccountsAsync_WhenOneAccountHasBadBalance_ShouldRefreshRemainingAccounts()
+    {
+        // Arrange
+        var helper = new TestHelper();
+
+        // First account has an empty balance string — decimal.Parse will throw.
+        // Second account is valid and must still be refreshed.
+        var jsonResponse =
+            @"{
+            ""errors"": [],
+            ""accounts"": [
+                {
+                    ""org"": {
+                        ""domain"": ""example.com"",
+                        ""sfin-url"": ""https://example.com/simplefin"",
+                        ""name"": ""Example Bank"",
+                        ""url"": ""https://example.com"",
+                        ""id"": ""org-123""
+                    },
+                    ""id"": ""account-bad"",
+                    ""name"": ""Bad Balance Account"",
+                    ""currency"": ""USD"",
+                    ""balance"": """",
+                    ""balance-date"": 1609459200,
+                    ""transactions"": []
+                },
+                {
+                    ""org"": {
+                        ""domain"": ""example.com"",
+                        ""sfin-url"": ""https://example.com/simplefin"",
+                        ""name"": ""Example Bank"",
+                        ""url"": ""https://example.com"",
+                        ""id"": ""org-123""
+                    },
+                    ""id"": ""account-valid"",
+                    ""name"": ""Valid Account"",
+                    ""currency"": ""USD"",
+                    ""balance"": ""1000.50"",
+                    ""balance-date"": 1609459200,
+                    ""transactions"": []
+                }
+            ]
+        }";
+
+        var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(
+                new HttpResponseMessage
+                {
+                    StatusCode = System.Net.HttpStatusCode.OK,
+                    Content = new StringContent(jsonResponse),
+                }
+            );
+
+        using var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        httpClientFactoryMock
+            .Setup(_ => _.CreateClient(string.Empty))
+            .Returns(httpClient)
+            .Verifiable();
+
+        var simpleFinOrganizationServiceMock = new Mock<ISimpleFinOrganizationService>();
+        simpleFinOrganizationServiceMock
+            .Setup(s =>
+                s.CreateSimpleFinOrganizationAsync(
+                    helper.demoUser.Id,
+                    It.IsAny<ISimpleFinOrganizationCreateRequest>()
+                )
+            )
+            .Callback<Guid, ISimpleFinOrganizationCreateRequest>(
+                (userId, request) =>
+                {
+                    var org = new Database.Models.SimpleFinOrganization
+                    {
+                        Domain = request.Domain,
+                        SimpleFinUrl = request.SimpleFinUrl,
+                        Name = request.Name,
+                        Url = request.Url,
+                        SyncID = request.SyncID,
+                        UserID = userId,
+                    };
+                    helper.UserDataContext.SimpleFinOrganizations.Add(org);
+                    helper.UserDataContext.SaveChanges();
+                }
+            )
+            .Returns(Task.CompletedTask);
+        var simpleFinAccountServiceMock = new Mock<ISimpleFinAccountService>();
+
+        var simpleFinService = new SimpleFinService(
+            httpClientFactoryMock.Object,
+            helper.UserDataContext,
+            Mock.Of<ILogger<ISimpleFinService>>(),
+            Mock.Of<INowProvider>(),
+            Mock.Of<IAccountService>(),
+            Mock.Of<ITransactionService>(),
+            Mock.Of<IBalanceService>(),
+            simpleFinOrganizationServiceMock.Object,
+            simpleFinAccountServiceMock.Object,
+            TestHelper.CreateMockLocalizer<ResponseStrings>(),
+            TestHelper.CreateMockLocalizer<LogStrings>()
+        );
+
+        helper.demoUser.SimpleFinAccessToken = "https://demo:demo@test.com/simplefin";
+        helper.UserDataContext.SaveChanges();
+
+        // Act
+        var errors = await simpleFinService.RefreshAccountsAsync(helper.demoUser.Id);
+
+        // Assert: the valid account was still created despite the bad-balance account throwing
+        simpleFinAccountServiceMock.Verify(
+            s =>
+                s.CreateSimpleFinAccountAsync(
+                    helper.demoUser.Id,
+                    It.Is<ISimpleFinAccountCreateRequest>(r => r.SyncID == "account-valid")
+                ),
+            Times.Once
+        );
+        simpleFinAccountServiceMock.Verify(
+            s =>
+                s.CreateSimpleFinAccountAsync(
+                    helper.demoUser.Id,
+                    It.Is<ISimpleFinAccountCreateRequest>(r => r.SyncID == "account-bad")
+                ),
+            Times.Never
+        );
+
+        // Assert: an error is reported for the bad-balance account
+        errors.Should().NotBeEmpty();
+        errors.Should().Contain(e => e.Contains("SimpleFinAccountSyncException"));
+    }
+
+    [Fact]
     public async Task RemoveAccessTokenAsync_WhenCalledWithInvalidUserId_ShouldThrowException()
     {
         // Arrange

--- a/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
+++ b/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
@@ -1651,9 +1651,6 @@ public class SimpleFinServiceTests
     public async Task SyncTransactionHistoryAsync_WhenOneAccountThrowsDuringSync_ShouldSyncRemainingAccounts()
     {
         // Arrange
-        // Regression test for: when one account has bad data (e.g., empty balance from a
-        // bank that requires reauthentication), an unhandled exception must not abort
-        // sync for subsequent accounts in the loop.
         var helper = new TestHelper();
 
         // First account has an empty balance (causes decimal.Parse to throw).
@@ -1747,7 +1744,7 @@ public class SimpleFinServiceTests
             TestHelper.CreateMockLocalizer<LogStrings>()
         );
 
-        var org = new Database.Models.SimpleFinOrganization
+        var org = new SimpleFinOrganization
         {
             Domain = "example.com",
             SimpleFinUrl = "https://example.com/simplefin",
@@ -1757,7 +1754,7 @@ public class SimpleFinServiceTests
         helper.UserDataContext.SimpleFinOrganizations.Add(org);
 
         // Bad-balance account: linked so sync is attempted and the parse throws.
-        var accountBad = new Database.Models.Account
+        var accountBad = new Account
         {
             Name = "Bad Balance",
             Type = "checking",
@@ -1766,7 +1763,7 @@ public class SimpleFinServiceTests
         };
         helper.UserDataContext.Accounts.Add(accountBad);
 
-        var simpleFinAccountBad = new Database.Models.SimpleFinAccount
+        var simpleFinAccountBad = new SimpleFinAccount
         {
             SyncID = "account-bad-balance",
             Name = "Bad Balance Account",
@@ -1781,7 +1778,7 @@ public class SimpleFinServiceTests
         helper.UserDataContext.SimpleFinAccounts.Add(simpleFinAccountBad);
 
         // Valid account: should sync even though the previous account threw.
-        var accountValid = new Database.Models.Account
+        var accountValid = new Account
         {
             Name = "Valid Checking",
             Type = "checking",
@@ -1790,7 +1787,7 @@ public class SimpleFinServiceTests
         };
         helper.UserDataContext.Accounts.Add(accountValid);
 
-        var simpleFinAccountValid = new Database.Models.SimpleFinAccount
+        var simpleFinAccountValid = new SimpleFinAccount
         {
             SyncID = "account-valid",
             Name = "Valid Account",

--- a/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
+++ b/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
@@ -1811,7 +1811,7 @@ public class SimpleFinServiceTests
         transactionServiceMock.Verify(
             s =>
                 s.CreateTransactionAsync(
-                    helper.demoUser,
+                    It.Is<ApplicationUser>(u => u.Id == helper.demoUser.Id),
                     It.IsAny<ITransactionCreateRequest>(),
                     It.IsAny<IEnumerable<ICategory>>(),
                     It.IsAny<AutomaticTransactionCategorizerHelper>()
@@ -1825,6 +1825,6 @@ public class SimpleFinServiceTests
 
         // Assert: an error is reported for the bad-balance account
         errors.Should().NotBeEmpty();
-        errors.Should().Contain(e => e.Contains("Bad Balance Account"));
+        errors.Should().Contain(e => e.Contains("SimpleFinAccountSyncException"));
     }
 }

--- a/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
+++ b/server/BudgetBoard.Tests/SimpleFinServiceTests.cs
@@ -1646,4 +1646,188 @@ public class SimpleFinServiceTests
             Times.Exactly(2)
         );
     }
+
+    [Fact]
+    public async Task SyncTransactionHistoryAsync_WhenOneAccountThrowsDuringSync_ShouldSyncRemainingAccounts()
+    {
+        // Arrange
+        // Regression test for: when one account has bad data (e.g., empty balance from a
+        // bank that requires reauthentication), an unhandled exception must not abort
+        // sync for subsequent accounts in the loop.
+        var helper = new TestHelper();
+
+        // First account has an empty balance (causes decimal.Parse to throw).
+        // Second account is valid and must still be synced.
+        var jsonResponse =
+            @"{
+            ""errors"": [],
+            ""accounts"": [
+                {
+                    ""org"": {
+                        ""domain"": ""example.com"",
+                        ""sfin-url"": ""https://example.com/simplefin"",
+                        ""name"": ""Example Bank"",
+                        ""url"": ""https://example.com"",
+                        ""id"": ""org-123""
+                    },
+                    ""id"": ""account-bad-balance"",
+                    ""name"": ""Bad Balance Account"",
+                    ""currency"": ""USD"",
+                    ""balance"": """",
+                    ""balance-date"": 1609459200,
+                    ""transactions"": []
+                },
+                {
+                    ""org"": {
+                        ""domain"": ""example.com"",
+                        ""sfin-url"": ""https://example.com/simplefin"",
+                        ""name"": ""Example Bank"",
+                        ""url"": ""https://example.com"",
+                        ""id"": ""org-123""
+                    },
+                    ""id"": ""account-valid"",
+                    ""name"": ""Valid Account"",
+                    ""currency"": ""USD"",
+                    ""balance"": ""2500.00"",
+                    ""balance-date"": 1609459200,
+                    ""transactions"": [
+                        {
+                            ""id"": ""txn-1"",
+                            ""posted"": 1609372800,
+                            ""amount"": ""-25.00"",
+                            ""description"": ""Grocery Store"",
+                            ""transacted_at"": 1609372800,
+                            ""pending"": false
+                        }
+                    ]
+                }
+            ]
+        }";
+
+        var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(
+                new HttpResponseMessage
+                {
+                    StatusCode = System.Net.HttpStatusCode.OK,
+                    Content = new StringContent(jsonResponse),
+                }
+            );
+
+        using var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        httpClientFactoryMock
+            .Setup(_ => _.CreateClient(string.Empty))
+            .Returns(httpClient)
+            .Verifiable();
+
+        var nowProviderMock = Mock.Of<INowProvider>();
+        Mock.Get(nowProviderMock).Setup(_ => _.UtcNow).Returns(DateTime.UtcNow);
+
+        var transactionServiceMock = new Mock<ITransactionService>();
+        var balanceServiceMock = new Mock<IBalanceService>();
+
+        var simpleFinService = new SimpleFinService(
+            httpClientFactoryMock.Object,
+            helper.UserDataContext,
+            Mock.Of<ILogger<ISimpleFinService>>(),
+            nowProviderMock,
+            Mock.Of<IAccountService>(),
+            transactionServiceMock.Object,
+            balanceServiceMock.Object,
+            Mock.Of<ISimpleFinOrganizationService>(),
+            Mock.Of<ISimpleFinAccountService>(),
+            TestHelper.CreateMockLocalizer<ResponseStrings>(),
+            TestHelper.CreateMockLocalizer<LogStrings>()
+        );
+
+        var org = new Database.Models.SimpleFinOrganization
+        {
+            Domain = "example.com",
+            SimpleFinUrl = "https://example.com/simplefin",
+            Name = "Example Bank",
+            UserID = helper.demoUser.Id,
+        };
+        helper.UserDataContext.SimpleFinOrganizations.Add(org);
+
+        // Bad-balance account: linked so sync is attempted and the parse throws.
+        var accountBad = new Database.Models.Account
+        {
+            Name = "Bad Balance",
+            Type = "checking",
+            Subtype = "checking",
+            UserID = helper.demoUser.Id,
+        };
+        helper.UserDataContext.Accounts.Add(accountBad);
+
+        var simpleFinAccountBad = new Database.Models.SimpleFinAccount
+        {
+            SyncID = "account-bad-balance",
+            Name = "Bad Balance Account",
+            Currency = "USD",
+            Balance = 500.00m,
+            BalanceDate = (int)new DateTimeOffset(DateTime.UtcNow.AddDays(-2)).ToUnixTimeSeconds(),
+            OrganizationId = org.ID,
+            LinkedAccountId = accountBad.ID,
+            UserID = helper.demoUser.Id,
+            LastSync = DateTime.UtcNow.AddDays(-1),
+        };
+        helper.UserDataContext.SimpleFinAccounts.Add(simpleFinAccountBad);
+
+        // Valid account: should sync even though the previous account threw.
+        var accountValid = new Database.Models.Account
+        {
+            Name = "Valid Checking",
+            Type = "checking",
+            Subtype = "checking",
+            UserID = helper.demoUser.Id,
+        };
+        helper.UserDataContext.Accounts.Add(accountValid);
+
+        var simpleFinAccountValid = new Database.Models.SimpleFinAccount
+        {
+            SyncID = "account-valid",
+            Name = "Valid Account",
+            Currency = "USD",
+            Balance = 2000.00m,
+            BalanceDate = (int)new DateTimeOffset(DateTime.UtcNow.AddDays(-2)).ToUnixTimeSeconds(),
+            OrganizationId = org.ID,
+            LinkedAccountId = accountValid.ID,
+            UserID = helper.demoUser.Id,
+            LastSync = DateTime.UtcNow.AddDays(-1),
+        };
+        helper.UserDataContext.SimpleFinAccounts.Add(simpleFinAccountValid);
+
+        helper.demoUser.SimpleFinAccessToken = "https://demo:demo@test.com/simplefin";
+        helper.UserDataContext.SaveChanges();
+
+        // Act
+        var errors = await simpleFinService.SyncTransactionHistoryAsync(helper.demoUser.Id);
+
+        // Assert: the valid account still synced despite the bad-balance account throwing
+        transactionServiceMock.Verify(
+            s =>
+                s.CreateTransactionAsync(
+                    helper.demoUser,
+                    It.IsAny<ITransactionCreateRequest>(),
+                    It.IsAny<IEnumerable<ICategory>>(),
+                    It.IsAny<AutomaticTransactionCategorizerHelper>()
+                ),
+            Times.Once
+        );
+        balanceServiceMock.Verify(
+            s => s.CreateBalancesAsync(helper.demoUser.Id, It.IsAny<IBalanceCreateRequest>()),
+            Times.Once
+        );
+
+        // Assert: an error is reported for the bad-balance account
+        errors.Should().NotBeEmpty();
+        errors.Should().Contain(e => e.Contains("Bad Balance Account"));
+    }
 }


### PR DESCRIPTION
If an exception occurs during sync, it could force the sync to stop and miss some working accounts. Need to catch the exception and move on to the next account.