### PR TITLE
Adjust widget instance limits

### DIFF
--- a/client/src/shared/dashboardGrid.ts
+++ b/client/src/shared/dashboardGrid.ts
@@ -14,7 +14,7 @@ export const WIDGET_REGISTRY: WidgetRegistryEntry[] = [
     widgetType: "Accounts",
     labelKey: "accounts",
     descriptionKey: "accounts_widget_description",
-    maxInstances: 1,
+    maxInstances: Infinity,
   },
   {
     widgetType: "NetWorth",
@@ -32,7 +32,7 @@ export const WIDGET_REGISTRY: WidgetRegistryEntry[] = [
     widgetType: "SpendingTrends",
     labelKey: "spending_trends",
     descriptionKey: "spending_trends_widget_description",
-    maxInstances: Infinity,
+    maxInstances: 1,
   },
   {
     widgetType: "Metric",


### PR DESCRIPTION
- Accounts could reasonably be configured to show different things for each instance, so we should allow more than 1
- Spending trends is static, so nobody should need more than 1
- Uncategorized transactions is also static so cap at 1