### PR TITLE
Make budgets dateonly

### DIFF
--- a/client/src/app/Authorized/PageContent/Budgets/Budgets.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/Budgets.tsx
@@ -15,7 +15,8 @@ import { useTransactionCategories } from "~/providers/TransactionCategoryProvide
 import { useLocale } from "~/providers/LocaleProvider/LocaleProvider";
 
 const Budgets = (): React.ReactNode => {
-  const { allTransactionCategories: transactionCategories } = useTransactionCategories();
+  const { allTransactionCategories: transactionCategories } =
+    useTransactionCategories();
   const { dayjs } = useLocale();
   const { request } = useAuth();
 
@@ -25,12 +26,12 @@ const Budgets = (): React.ReactNode => {
 
   const budgetsQuery = useQueries({
     queries: selectedDates.map((date: Date) => ({
-      queryKey: ["budgets", date],
+      queryKey: ["budgets", dayjs(date).format("YYYY-MM")],
       queryFn: async (): Promise<IBudget[]> => {
         const res: AxiosResponse = await request({
           url: "/api/budget",
           method: "GET",
-          params: { date },
+          params: { month: dayjs(date).format("YYYY-MM-DD") },
         });
 
         if (res.status === 200) {

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/UnbudgetChildCard/UnbudgetChildCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/BudgetsGroup/BudgetParentCard/UnbudgetChildCard/UnbudgetChildCard.tsx
@@ -25,7 +25,7 @@ interface UnbudgetChildCardProps {
 }
 
 const UnbudgetChildCard = (props: UnbudgetChildCardProps): React.ReactNode => {
-  const { intlLocale } = useLocale();
+  const { intlLocale, dayjs } = useLocale();
   const { request } = useAuth();
 
   const userSettingsQuery = useQuery({
@@ -109,7 +109,7 @@ const UnbudgetChildCard = (props: UnbudgetChildCardProps): React.ReactNode => {
                   event.stopPropagation();
                   doAddBudget.mutate([
                     {
-                      date: props.selectedDate!,
+                      month: dayjs(props.selectedDate!).format("YYYY-MM-DD"),
                       category: props.category,
                       limit: Math.round(Math.abs(props.amount)),
                     },

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/UnbudgetedGroup/UnbudgetedCard/UnbudgetedCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/UnbudgetedGroup/UnbudgetedCard/UnbudgetedCard.tsx
@@ -27,7 +27,7 @@ interface UnbudgetedCardProps {
 
 const UnbudgetedCard = (props: UnbudgetedCardProps): React.ReactNode => {
   const { t } = useTranslation();
-  const { intlLocale } = useLocale();
+  const { intlLocale, dayjs } = useLocale();
   const { request } = useAuth();
 
   const userSettingsQuery = useQuery({
@@ -152,7 +152,7 @@ const UnbudgetedCard = (props: UnbudgetedCardProps): React.ReactNode => {
                   event.stopPropagation();
                   doAddBudget.mutate([
                     {
-                      date: props.selectedDate!,
+                      month: dayjs(props.selectedDate!).format("YYYY-MM-DD"),
                       category: props.categoryTree.value,
                       limit: Math.round(
                         Math.abs(

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/UnbudgetedGroup/UnbudgetedCard/UnbudgetedChildCard/UnbudgetedChildCard.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsContent/UnbudgetedGroup/UnbudgetedCard/UnbudgetedChildCard/UnbudgetedChildCard.tsx
@@ -26,7 +26,7 @@ interface UnbudgetedChildCardProps {
 const UnbudgetedChildCard = (
   props: UnbudgetedChildCardProps,
 ): React.ReactNode => {
-  const { intlLocale } = useLocale();
+  const { intlLocale, dayjs } = useLocale();
   const { request } = useAuth();
 
   const userSettingsQuery = useQuery({
@@ -104,7 +104,7 @@ const UnbudgetedChildCard = (
                   e.stopPropagation();
                   doAddBudget.mutate([
                     {
-                      date: props.selectedDate!,
+                      month: dayjs(props.selectedDate!).format("YYYY-MM-DD"),
                       category: props.category,
                       limit: Math.round(Math.abs(props.amount)),
                     },

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/AddBudget/AddBudget.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/AddBudget/AddBudget.tsx
@@ -30,7 +30,7 @@ interface AddBudgetProps {
 
 const AddBudget = (props: AddBudgetProps): React.ReactNode => {
   const { t } = useTranslation();
-  const { thousandsSeparator, decimalSeparator } = useLocale();
+  const { thousandsSeparator, decimalSeparator, dayjs } = useLocale();
 
   const categoryField = useField<string>({
     initialValue: "",
@@ -117,7 +117,7 @@ const AddBudget = (props: AddBudgetProps): React.ReactNode => {
               onClick={() =>
                 doCreateBudget.mutate([
                   {
-                    date: props.date,
+                    month: dayjs(props.date).format("YYYY-MM-DD"),
                     category: categoryField.getValue(),
                     limit:
                       limitField.getValue() === ""

--- a/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetsToolbar.tsx
+++ b/client/src/app/Authorized/PageContent/Budgets/BudgetsToolbar/BudgetsToolbar.tsx
@@ -14,6 +14,7 @@ import { translateAxiosError } from "~/helpers/requests";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
 import { SettingsIcon } from "lucide-react";
+import { useLocale } from "~/providers/LocaleProvider/LocaleProvider";
 
 interface BudgetsToolbarProps {
   categories: ICategory[];
@@ -30,6 +31,7 @@ const BudgetsToolbar = (props: BudgetsToolbarProps): React.ReactNode => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { request } = useAuth();
+  const { dayjs } = useLocale();
 
   const queryClient = useQueryClient();
   const doCopyBudget = useMutation({
@@ -42,7 +44,7 @@ const BudgetsToolbar = (props: BudgetsToolbarProps): React.ReactNode => {
       }),
     onSuccess: async (_, variables: IBudgetCreateRequest[]) =>
       await queryClient.invalidateQueries({
-        queryKey: ["budgets", variables[0]?.date],
+        queryKey: ["budgets", dayjs(variables[0]?.month).format("YYYY-MM")],
       }),
     onError: (error: AxiosError) =>
       notifications.show({
@@ -58,14 +60,14 @@ const BudgetsToolbar = (props: BudgetsToolbarProps): React.ReactNode => {
     request({
       url: "/api/budget",
       method: "GET",
-      params: { date: lastMonth },
+      params: { month: dayjs(lastMonth).format("YYYY-MM-DD") },
     })
       .then((res: AxiosResponse<any, any>) => {
         const budgets: IBudget[] = res.data;
         if (budgets.length !== 0) {
           const newBudgets: IBudgetCreateRequest[] = budgets.map((budget) => {
             return {
-              date: props.selectedDates[0],
+              month: dayjs(props.selectedDates[0]!).format("YYYY-MM-DD"),
               category: budget.category,
               limit: budget.limit,
             } as IBudgetCreateRequest;

--- a/client/src/components/core/Accordion/AccordionItem/AccordionItem.tsx
+++ b/client/src/components/core/Accordion/AccordionItem/AccordionItem.tsx
@@ -38,8 +38,7 @@ const AccordionItem = ({
         id={panelId}
         role="region"
         className={`${classes.panel} ${isOpen ? classes.panelOpen : ""}`}
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        {...(!isOpen ? ({ inert: "" } as any) : {})}
+        inert={!isOpen || undefined}
       >
         <div className={classes.panelInner}>
           <div

--- a/client/src/components/ui/widgets/MetricWidget/MetricWidget.tsx
+++ b/client/src/components/ui/widgets/MetricWidget/MetricWidget.tsx
@@ -41,7 +41,7 @@ const MetricWidget = ({
   const { t } = useTranslation();
   const { request } = useAuth();
   const { preferredCurrency } = useUserSettings();
-  const { intlLocale } = useLocale();
+  const { intlLocale, dayjs } = useLocale();
 
   const widgetSettingsQuery = useQuery({
     queryKey: ["widgetSettings"],
@@ -143,13 +143,13 @@ const MetricWidget = ({
 
   const budgetQueries = useQueries({
     queries: requirements.needsBudgets
-      ? requirements.budgetMonths.map((date) => ({
-          queryKey: ["budgets", date],
+      ? requirements.budgetMonths.map((date: Date) => ({
+          queryKey: ["budgets", dayjs(date).format("YYYY-MM")],
           queryFn: async (): Promise<IBudget[]> => {
             const res: AxiosResponse = await request({
               url: "/api/budget",
               method: "GET",
-              params: { date },
+              params: { month: dayjs(date).format("YYYY-MM-DD") },
             });
             if (res.status === 200) return res.data as IBudget[];
             return [];

--- a/client/src/helpers/metricWidget.ts
+++ b/client/src/helpers/metricWidget.ts
@@ -261,7 +261,7 @@ function resolveBudgets(
   const category = params["category"];
 
   let budgets = ctx.budgets.filter((b) =>
-    isInPeriod(new Date(b.date).toISOString(), period),
+    isInPeriod(dayjs(b.month).format("YYYY-MM-DD"), period),
   );
 
   if (category) {

--- a/client/src/models/budget.ts
+++ b/client/src/models/budget.ts
@@ -1,5 +1,5 @@
 export interface IBudgetCreateRequest {
-  date: Date;
+  month: string;
   category: string;
   limit: number;
 }
@@ -11,7 +11,7 @@ export interface IBudgetUpdateRequest {
 
 export interface IBudget {
   id: string;
-  date: Date;
+  month: string;
   category: string;
   limit: number;
   userId: string;

--- a/server/BudgetBoard.Database/Migrations/20260606193707_BudgetMonthDateOnly.Designer.cs
+++ b/server/BudgetBoard.Database/Migrations/20260606193707_BudgetMonthDateOnly.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BudgetBoard.Database.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BudgetBoard.Database.Migrations
 {
     [DbContext(typeof(UserDataContext))]
-    partial class UserDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260606193707_BudgetMonthDateOnly")]
+    partial class BudgetMonthDateOnly
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/BudgetBoard.Database/Migrations/20260606193707_BudgetMonthDateOnly.cs
+++ b/server/BudgetBoard.Database/Migrations/20260606193707_BudgetMonthDateOnly.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BudgetBoard.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class BudgetMonthDateOnly : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Add the new Month column
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "Month",
+                table: "Budget",
+                type: "date",
+                nullable: false,
+                defaultValue: new DateOnly(1, 1, 1)
+            );
+
+            // Migrate data from Date to Month: extract year/month and normalize to first day of month (UTC)
+            migrationBuilder.Sql(
+                @"UPDATE ""Budget"" SET ""Month"" = make_date(
+                    EXTRACT(YEAR FROM (""Date"" AT TIME ZONE 'UTC'))::int,
+                    EXTRACT(MONTH FROM (""Date"" AT TIME ZONE 'UTC'))::int,
+                    1
+                )"
+            );
+
+            // Drop the old Date column
+            migrationBuilder.DropColumn(name: "Date", table: "Budget");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Add the Date column back
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Date",
+                table: "Budget",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified)
+            );
+
+            // Migrate data from Month back to Date (as UTC timestamp at start of month)
+            migrationBuilder.Sql(
+                @"UPDATE ""Budget"" SET ""Date"" = (""Month""::timestamp AT TIME ZONE 'UTC')"
+            );
+
+            // Drop the Month column
+            migrationBuilder.DropColumn(name: "Month", table: "Budget");
+        }
+    }
+}

--- a/server/BudgetBoard.Database/Models/Budget.cs
+++ b/server/BudgetBoard.Database/Models/Budget.cs
@@ -1,7 +1,7 @@
 ﻿namespace BudgetBoard.Database.Models;
 
 /// <summary>
-/// Represents a budget for a specific category and date.
+/// Represents a budget for a specific category and month.
 /// </summary>
 public class Budget
 {
@@ -11,9 +11,9 @@ public class Budget
     public Guid ID { get; set; } = Guid.NewGuid();
 
     /// <summary>
-    /// The date the budget applies to.
+    /// The month the budget applies to.
     /// </summary>
-    public required DateTime Date { get; set; }
+    public required DateOnly Month { get; set; }
 
     /// <summary>
     /// The category for which the budget is set.

--- a/server/BudgetBoard.Service/BudgetService.cs
+++ b/server/BudgetBoard.Service/BudgetService.cs
@@ -126,13 +126,13 @@ public class BudgetService(
     /// <inheritdoc />
     public async Task<IReadOnlyList<IBudgetResponse>> ReadBudgetsAsync(
         Guid userGuid,
-        DateTime monthDate
+        DateOnly month
     )
     {
         var userData = await GetCurrentUserAsync(userGuid.ToString());
 
         var budgets = userData.Budgets.Where(b =>
-            b.Date.Month == monthDate.Month && b.Date.Year == monthDate.Year
+            b.Month.Month == month.Month && b.Month.Year == month.Year
         );
 
         return budgets.Select(b => new BudgetResponse(b)).ToList();
@@ -158,7 +158,7 @@ public class BudgetService(
         {
             var childBudgetsLimitTotal = GetBudgetChildrenLimit(
                 budget.Category,
-                budget.Date,
+                budget.Month,
                 userData
             );
 
@@ -181,13 +181,13 @@ public class BudgetService(
             {
                 var parentBudget = userData.Budgets.SingleOrDefault(b =>
                     b.Category.Equals(parentCategory, StringComparison.CurrentCultureIgnoreCase)
-                    && b.Date.Month == budget.Date.Month
-                    && b.Date.Year == budget.Date.Year
+                    && b.Month.Month == budget.Month.Month
+                    && b.Month.Year == budget.Month.Year
                 );
 
                 var childBudgetsLimitTotal = GetBudgetChildrenLimit(
                     parentCategory,
-                    budget.Date,
+                    budget.Month,
                     userData
                 );
 
@@ -204,7 +204,7 @@ public class BudgetService(
                     // we should create a parent budget if it doesn't exist
                     var newParentBudget = new Budget
                     {
-                        Date = budget.Date,
+                        Month = budget.Month,
                         Category = parentCategory,
                         Limit = childBudgetsLimitTotal,
                         UserID = userData.Id,
@@ -247,7 +247,7 @@ public class BudgetService(
             var childBudgetsForMonth = GetChildBudgetsForMonth(
                 userData,
                 budget.Category,
-                budget.Date
+                budget.Month
             );
 
             foreach (var childBudget in childBudgetsForMonth)
@@ -262,7 +262,7 @@ public class BudgetService(
     private static List<Budget> GetChildBudgetsForMonth(
         ApplicationUser userData,
         string parentCategory,
-        DateTime monthDate
+        DateOnly monthDate
     )
     {
         var allCategories = TransactionCategoriesHelpers.GetAllTransactionCategories(userData);
@@ -275,7 +275,7 @@ public class BudgetService(
         );
 
         var childBudgetsForMonth = childBudgets
-            .Where(b => b.Date.Month == monthDate.Month && b.Date.Year == monthDate.Year)
+            .Where(b => b.Month.Month == monthDate.Month && b.Month.Year == monthDate.Year)
             .ToList();
 
         return childBudgetsForMonth ?? [];
@@ -283,7 +283,7 @@ public class BudgetService(
 
     private static decimal GetBudgetChildrenLimit(
         string parentCategory,
-        DateTime date,
+        DateOnly date,
         ApplicationUser userData
     ) => GetChildBudgetsForMonth(userData, parentCategory, date).Sum(b => b.Limit);
 
@@ -332,8 +332,8 @@ public class BudgetService(
         }
 
         var budgetForCategoryAlreadyExists = userData.Budgets.Any(b =>
-            b.Date.Month == request.Date.Month
-            && b.Date.Year == request.Date.Year
+            b.Month.Month == request.Month.Month
+            && b.Month.Year == request.Month.Year
             && b.Category.Equals(request.Category, StringComparison.CurrentCultureIgnoreCase)
         );
 
@@ -344,7 +344,7 @@ public class BudgetService(
                 _logLocalizer[
                     "BudgetCreateDuplicateLog",
                     request.Category,
-                    request.Date.ToString("yyyy-MM")
+                    request.Month.ToString("yyyy-MM")
                 ]
             );
 
@@ -352,13 +352,13 @@ public class BudgetService(
             return _responseLocalizer[
                 "BudgetCreateDuplicateError",
                 request.Category,
-                request.Date.ToString("yyyy-MM")
+                request.Month.ToString("yyyy-MM")
             ];
         }
 
         newBudget = new Budget
         {
-            Date = request.Date,
+            Month = request.Month,
             Category = request.Category,
             Limit = request.Limit,
             UserID = userData.Id,
@@ -394,9 +394,9 @@ public class BudgetService(
 
         var parentBudgetRequest = new BudgetCreateRequest
         {
-            Date = childRequest.Date,
+            Month = childRequest.Month,
             Category = parentCategory,
-            Limit = GetBudgetChildrenLimit(parentCategory, childRequest.Date, userData),
+            Limit = GetBudgetChildrenLimit(parentCategory, childRequest.Month, userData),
         };
 
         if (TryAddBudget(userData, parentBudgetRequest, out var newParentBudget) != null)
@@ -417,8 +417,8 @@ public class BudgetService(
     {
         var parentBudget = userData.Budgets.SingleOrDefault(b =>
             b.Category.Equals(parentCategory, StringComparison.CurrentCultureIgnoreCase)
-            && b.Date.Month == childBudget.Date.Month
-            && b.Date.Year == childBudget.Date.Year
+            && b.Month.Month == childBudget.Month.Month
+            && b.Month.Year == childBudget.Month.Year
         );
 
         if (parentBudget == null)

--- a/server/BudgetBoard.Service/DemoSeedService.cs
+++ b/server/BudgetBoard.Service/DemoSeedService.cs
@@ -493,7 +493,7 @@ public class DemoSeedService(
     private void SeedBudgetData(ApplicationUser user)
     {
         var today = DateTime.UtcNow;
-        var budgetMonth = new DateTime(today.Year, today.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var budgetMonth = new DateOnly(today.Year, today.Month, 1);
         var budgets = new (string Category, decimal Limit)[]
         {
             ("Food & Dining", 500m),
@@ -510,7 +510,7 @@ public class DemoSeedService(
             userDataContext.Budgets.Add(
                 new Budget
                 {
-                    Date = budgetMonth,
+                    Month = budgetMonth,
                     Category = category,
                     Limit = limit,
                     UserID = user.Id,

--- a/server/BudgetBoard.Service/Interfaces/IBudgetService.cs
+++ b/server/BudgetBoard.Service/Interfaces/IBudgetService.cs
@@ -34,7 +34,7 @@ public interface IBudgetService
     /// <param name="userGuid">The unique identifier of the user.</param>
     /// <param name="monthDate">The date indicating the month to retrieve budgets for.</param>
     /// <returns>A collection of budget details.</returns>
-    Task<IReadOnlyList<IBudgetResponse>> ReadBudgetsAsync(Guid userGuid, DateTime monthDate);
+    Task<IReadOnlyList<IBudgetResponse>> ReadBudgetsAsync(Guid userGuid, DateOnly month);
 
     /// <summary>
     /// Updates an existing budget entry.

--- a/server/BudgetBoard.Service/Interfaces/IBudgetService.cs
+++ b/server/BudgetBoard.Service/Interfaces/IBudgetService.cs
@@ -32,7 +32,7 @@ public interface IBudgetService
     /// Retrieves budgets for a specific month.
     /// </summary>
     /// <param name="userGuid">The unique identifier of the user.</param>
-    /// <param name="monthDate">The date indicating the month to retrieve budgets for.</param>
+    /// <param name="month">The date indicating the month to retrieve budgets for.</param>
     /// <returns>A collection of budget details.</returns>
     Task<IReadOnlyList<IBudgetResponse>> ReadBudgetsAsync(Guid userGuid, DateOnly month);
 
@@ -40,7 +40,7 @@ public interface IBudgetService
     /// Updates an existing budget entry.
     /// </summary>
     /// <param name="userGuid">The unique identifier of the user.</param>
-    /// <param name="updatedBudget">The budget update details.</param>
+    /// <param name="request">The budget update details.</param>
     Task UpdateBudgetAsync(Guid userGuid, IBudgetUpdateRequest request);
 
     /// <summary>

--- a/server/BudgetBoard.Service/Models/Budget.cs
+++ b/server/BudgetBoard.Service/Models/Budget.cs
@@ -5,21 +5,21 @@ namespace BudgetBoard.Service.Models;
 
 public interface IBudgetCreateRequest
 {
-    DateTime Date { get; }
+    DateOnly Month { get; }
     string Category { get; }
     decimal Limit { get; }
 }
 
 public class BudgetCreateRequest : IBudgetCreateRequest
 {
-    public DateTime Date { get; set; }
+    public DateOnly Month { get; set; }
     public string Category { get; set; }
     public decimal Limit { get; set; }
 
     [JsonConstructor]
     public BudgetCreateRequest()
     {
-        Date = DateTime.MinValue;
+        Month = DateOnly.MinValue;
         Category = string.Empty;
         Limit = 0;
     }
@@ -47,7 +47,7 @@ public class BudgetUpdateRequest : IBudgetUpdateRequest
 public interface IBudgetResponse
 {
     Guid ID { get; }
-    DateTime Date { get; }
+    DateOnly Month { get; }
     string Category { get; }
     decimal Limit { get; }
     Guid UserID { get; }
@@ -56,7 +56,7 @@ public interface IBudgetResponse
 public class BudgetResponse : IBudgetResponse
 {
     public Guid ID { get; set; }
-    public DateTime Date { get; set; }
+    public DateOnly Month { get; set; }
     public string Category { get; set; }
     public decimal Limit { get; set; }
     public Guid UserID { get; set; }
@@ -65,7 +65,7 @@ public class BudgetResponse : IBudgetResponse
     public BudgetResponse()
     {
         ID = Guid.NewGuid();
-        Date = DateTime.MinValue;
+        Month = DateOnly.MinValue;
         Category = string.Empty;
         Limit = 0;
         UserID = Guid.NewGuid();
@@ -74,7 +74,7 @@ public class BudgetResponse : IBudgetResponse
     public BudgetResponse(Budget budget)
     {
         ID = budget.ID;
-        Date = budget.Date;
+        Month = budget.Month;
         Category = budget.Category;
         Limit = budget.Limit;
         UserID = budget.UserID;

--- a/server/BudgetBoard.Tests/BudgetServiceTests.cs
+++ b/server/BudgetBoard.Tests/BudgetServiceTests.cs
@@ -17,11 +17,11 @@ public class BudgetServiceTests
         new Faker<BudgetCreateRequest>()
             .RuleFor(
                 b => b.Month,
-                f => new DateOnly(
-                    f.Date.Between(DateTime.Now.AddMonths(-2), DateTime.Now).Year,
-                    f.Date.Between(DateTime.Now.AddMonths(-2), DateTime.Now).Month,
-                    1
-                )
+                f =>
+                {
+                    var randomDate = f.Date.Between(DateTime.Now.AddMonths(-2), DateTime.Now);
+                    return new DateOnly(randomDate.Year, randomDate.Month, 1);
+                }
             )
             .RuleFor(
                 b => b.Category,
@@ -584,15 +584,15 @@ public class BudgetServiceTests
         var budgetFaker = new BudgetFaker(helper.demoUser.Id);
 
         var januaryBudget = budgetFaker.Generate();
-        januaryBudget.Month = new DateOnly(2026, 1, 15);
+        januaryBudget.Month = new DateOnly(2026, 1, 1);
         januaryBudget.Category = "January Budget";
 
         var februaryBudget = budgetFaker.Generate();
-        februaryBudget.Month = new DateOnly(2026, 2, 15);
+        februaryBudget.Month = new DateOnly(2026, 2, 1);
         februaryBudget.Category = "February Budget";
 
         var marchBudget = budgetFaker.Generate();
-        marchBudget.Month = new DateOnly(2026, 3, 15);
+        marchBudget.Month = new DateOnly(2026, 3, 1);
         marchBudget.Category = "March Budget";
 
         helper.UserDataContext.Budgets.AddRange([januaryBudget, februaryBudget, marchBudget]);

--- a/server/BudgetBoard.Tests/BudgetServiceTests.cs
+++ b/server/BudgetBoard.Tests/BudgetServiceTests.cs
@@ -15,7 +15,14 @@ public class BudgetServiceTests
 {
     private readonly Faker<BudgetCreateRequest> _budgetCreateRequestFaker =
         new Faker<BudgetCreateRequest>()
-            .RuleFor(b => b.Date, f => f.Date.Past())
+            .RuleFor(
+                b => b.Month,
+                f => new DateOnly(
+                    f.Date.Between(DateTime.Now.AddMonths(-2), DateTime.Now).Year,
+                    f.Date.Between(DateTime.Now.AddMonths(-2), DateTime.Now).Month,
+                    1
+                )
+            )
             .RuleFor(
                 b => b.Category,
                 (f, b) =>
@@ -44,19 +51,19 @@ public class BudgetServiceTests
             TestHelper.CreateMockLocalizer<LogStrings>()
         );
 
-        var today = DateTime.Today;
+        var today = DateOnly.FromDateTime(DateTime.Today);
         var budgets = new List<BudgetCreateRequest>();
         var newBudget1 = _budgetCreateRequestFaker.Generate();
         newBudget1.Category = "Paycheck";
-        newBudget1.Date = today;
+        newBudget1.Month = today;
         budgets.Add(newBudget1);
         var newBudget2 = _budgetCreateRequestFaker.Generate();
         newBudget2.Category = "Bonus";
-        newBudget2.Date = today;
+        newBudget2.Month = today;
         budgets.Add(newBudget2);
         var newBudget3 = _budgetCreateRequestFaker.Generate();
         newBudget3.Category = "Service & Parts";
-        newBudget3.Date = today;
+        newBudget3.Month = today;
         budgets.Add(newBudget3);
 
         // Act
@@ -81,22 +88,22 @@ public class BudgetServiceTests
             TestHelper.CreateMockLocalizer<LogStrings>()
         );
 
-        var today = DateTime.Today;
+        var today = DateOnly.FromDateTime(DateTime.Today);
 
         var child1 = _budgetCreateRequestFaker.Generate();
         child1.Category = "Paycheck";
         child1.Limit = 1000;
-        child1.Date = today;
+        child1.Month = today;
 
         var child2 = _budgetCreateRequestFaker.Generate();
         child2.Category = "Bonus";
         child2.Limit = 500;
-        child2.Date = today;
+        child2.Month = today;
 
         var child3 = _budgetCreateRequestFaker.Generate();
         child3.Category = "Interest Income";
         child3.Limit = 300;
-        child3.Date = today;
+        child3.Month = today;
 
         // Act
         await budgetService.CreateBudgetsWithParentsAsync(
@@ -168,17 +175,17 @@ public class BudgetServiceTests
             TestHelper.CreateMockLocalizer<LogStrings>()
         );
 
-        var today = DateTime.Today;
+        var today = DateOnly.FromDateTime(DateTime.Today);
         var category = "Food & Dining";
 
         var budget1 = _budgetCreateRequestFaker.Generate();
         budget1.Category = category;
-        budget1.Date = today;
+        budget1.Month = today;
         await budgetService.CreateBudgetsAsync(helper.demoUser.Id, [budget1]);
 
         var budget2 = _budgetCreateRequestFaker.Generate();
         budget2.Category = category;
-        budget2.Date = today;
+        budget2.Month = today;
 
         // Act
         Func<Task> act = async () =>
@@ -206,21 +213,21 @@ public class BudgetServiceTests
         var child1Budget = budgetFaker.Generate();
         child1Budget.Category = "Bonus";
         child1Budget.Limit = 1000;
-        child1Budget.Date = DateTime.Today;
+        child1Budget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(child1Budget);
 
         var child2Budget = budgetFaker.Generate();
         child2Budget.Category = "Service & Parts";
         child2Budget.Limit = 200;
-        child2Budget.Date = DateTime.Today;
+        child2Budget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(child2Budget);
 
         var child3Budget = budgetFaker.Generate();
         child3Budget.Category = "Paycheck";
         child3Budget.Limit = 300;
-        child3Budget.Date = DateTime.Today.AddMonths(-1);
+        child3Budget.Month = DateOnly.FromDateTime(DateTime.Today.AddMonths(-1));
 
         helper.UserDataContext.Budgets.Add(child3Budget);
 
@@ -229,7 +236,7 @@ public class BudgetServiceTests
         var budget = _budgetCreateRequestFaker.Generate();
         budget.Category = "Paycheck";
         budget.Limit = 200;
-        budget.Date = DateTime.Today;
+        budget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         // Act
         await budgetService.CreateBudgetsWithParentsAsync(helper.demoUser.Id, [budget]);
@@ -258,7 +265,7 @@ public class BudgetServiceTests
         var parentBudget = budgetFaker.Generate();
         parentBudget.Category = "Income";
         parentBudget.Limit = 1000;
-        parentBudget.Date = DateTime.Today;
+        parentBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(parentBudget);
         helper.UserDataContext.SaveChanges();
@@ -266,7 +273,7 @@ public class BudgetServiceTests
         var budget = _budgetCreateRequestFaker.Generate();
         budget.Category = "Paycheck";
         budget.Limit = 200;
-        budget.Date = DateTime.Today;
+        budget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         var oldLimit = parentBudget.Limit;
 
@@ -295,7 +302,7 @@ public class BudgetServiceTests
         var parentBudget = budgetFaker.Generate();
         parentBudget.Category = "Income";
         parentBudget.Limit = 1000;
-        parentBudget.Date = DateTime.Today;
+        parentBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(parentBudget);
         helper.UserDataContext.SaveChanges();
@@ -303,7 +310,7 @@ public class BudgetServiceTests
         var budget = _budgetCreateRequestFaker.Generate();
         budget.Category = "Paycheck";
         budget.Limit = 200;
-        budget.Date = DateTime.Today;
+        budget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         // Act
         await budgetService.CreateBudgetsWithParentsAsync(helper.demoUser.Id, [budget]);
@@ -330,7 +337,7 @@ public class BudgetServiceTests
         var budget = _budgetCreateRequestFaker.Generate();
         budget.Category = "Paycheck";
         budget.Limit = 200;
-        budget.Date = DateTime.Today;
+        budget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         // Act
         await budgetService.CreateBudgetsAsync(helper.demoUser.Id, [budget]);
@@ -403,14 +410,14 @@ public class BudgetServiceTests
         );
 
         var validBudget1 = _budgetCreateRequestFaker.Generate();
-        validBudget1.Date = DateTime.Today;
+        validBudget1.Month = DateOnly.FromDateTime(DateTime.Today);
 
         var invalidBudget = _budgetCreateRequestFaker.Generate();
         invalidBudget.Category = null!;
-        invalidBudget.Date = DateTime.Today;
+        invalidBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         var validBudget2 = _budgetCreateRequestFaker.Generate();
-        validBudget2.Date = DateTime.Today;
+        validBudget2.Month = DateOnly.FromDateTime(DateTime.Today);
 
         // Act
         Func<Task> act = async () =>
@@ -491,7 +498,10 @@ public class BudgetServiceTests
         helper.UserDataContext.SaveChanges();
 
         // Act
-        var result = await budgetService.ReadBudgetsAsync(helper.demoUser.Id, DateTime.Now);
+        var result = await budgetService.ReadBudgetsAsync(
+            helper.demoUser.Id,
+            DateOnly.FromDateTime(DateTime.Now)
+        );
 
         // Assert
         result
@@ -499,7 +509,7 @@ public class BudgetServiceTests
             .HaveCount(
                 budgets
                     .Where(b =>
-                        b.Date.Month == DateTime.Now.Month && b.Date.Year == DateTime.Now.Year
+                        b.Month.Month == DateTime.Now.Month && b.Month.Year == DateTime.Now.Year
                     )
                     .Count()
             );
@@ -507,7 +517,7 @@ public class BudgetServiceTests
             .Should()
             .BeEquivalentTo(
                 budgets
-                    .Where(b => b.Date.Month == DateTime.Now.Month)
+                    .Where(b => b.Month.Month == DateTime.Now.Month)
                     .Select(b => new BudgetResponse(b))
             );
     }
@@ -526,7 +536,10 @@ public class BudgetServiceTests
 
         // Act
         Func<Task> act = async () =>
-            await budgetService.ReadBudgetsAsync(Guid.NewGuid(), DateTime.Now);
+            await budgetService.ReadBudgetsAsync(
+                Guid.NewGuid(),
+                DateOnly.FromDateTime(DateTime.Now)
+            );
 
         // Assert
         await act.Should()
@@ -547,7 +560,10 @@ public class BudgetServiceTests
         );
 
         // Act
-        var result = await budgetService.ReadBudgetsAsync(helper.demoUser.Id, DateTime.Now);
+        var result = await budgetService.ReadBudgetsAsync(
+            helper.demoUser.Id,
+            DateOnly.FromDateTime(DateTime.Now)
+        );
 
         // Assert
         result.Should().BeEmpty();
@@ -568,15 +584,15 @@ public class BudgetServiceTests
         var budgetFaker = new BudgetFaker(helper.demoUser.Id);
 
         var januaryBudget = budgetFaker.Generate();
-        januaryBudget.Date = new DateTime(2026, 1, 15);
+        januaryBudget.Month = new DateOnly(2026, 1, 15);
         januaryBudget.Category = "January Budget";
 
         var februaryBudget = budgetFaker.Generate();
-        februaryBudget.Date = new DateTime(2026, 2, 15);
+        februaryBudget.Month = new DateOnly(2026, 2, 15);
         februaryBudget.Category = "February Budget";
 
         var marchBudget = budgetFaker.Generate();
-        marchBudget.Date = new DateTime(2026, 3, 15);
+        marchBudget.Month = new DateOnly(2026, 3, 15);
         marchBudget.Category = "March Budget";
 
         helper.UserDataContext.Budgets.AddRange([januaryBudget, februaryBudget, marchBudget]);
@@ -585,7 +601,7 @@ public class BudgetServiceTests
         // Act
         var result = await budgetService.ReadBudgetsAsync(
             helper.demoUser.Id,
-            new DateTime(2026, 2, 1)
+            new DateOnly(2026, 2, 1)
         );
 
         // Assert
@@ -670,14 +686,14 @@ public class BudgetServiceTests
         var parentBudget = budgetFaker.Generate();
         parentBudget.Category = "Income";
         parentBudget.Limit = parentLimit;
-        parentBudget.Date = DateTime.Today;
+        parentBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(parentBudget);
 
         var childBudget = budgetFaker.Generate();
         childBudget.Category = "Paycheck";
         childBudget.Limit = 200;
-        childBudget.Date = DateTime.Today;
+        childBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(childBudget);
 
@@ -686,7 +702,7 @@ public class BudgetServiceTests
         var otherChildBudget = budgetFaker.Generate();
         otherChildBudget.Category = "Bonus";
         otherChildBudget.Limit = otherChildBudgetLimit;
-        otherChildBudget.Date = DateTime.Today;
+        otherChildBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(otherChildBudget);
         helper.UserDataContext.SaveChanges();
@@ -725,14 +741,14 @@ public class BudgetServiceTests
         var parentBudget = budgetFaker.Generate();
         parentBudget.Category = "Income";
         parentBudget.Limit = parentLimit;
-        parentBudget.Date = DateTime.Today;
+        parentBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(parentBudget);
 
         var childBudget = budgetFaker.Generate();
         childBudget.Category = "Paycheck";
         childBudget.Limit = 200;
-        childBudget.Date = DateTime.Today;
+        childBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(childBudget);
         helper.UserDataContext.SaveChanges();
@@ -768,7 +784,7 @@ public class BudgetServiceTests
         var childBudget = budgetFaker.Generate();
         childBudget.Category = "Paycheck";
         childBudget.Limit = 200;
-        childBudget.Date = DateTime.Today;
+        childBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(childBudget);
         helper.UserDataContext.SaveChanges();
@@ -806,7 +822,7 @@ public class BudgetServiceTests
         var parentBudget = budgetFaker.Generate();
         parentBudget.Category = "Income";
         parentBudget.Limit = 1000;
-        parentBudget.Date = DateTime.Today;
+        parentBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(parentBudget);
         var childBudget = budgetFaker.Generate();
@@ -814,7 +830,7 @@ public class BudgetServiceTests
         childBudget.UserID = helper.demoUser.Id;
         childBudget.Category = "Paycheck";
         childBudget.Limit = 200;
-        childBudget.Date = DateTime.Today;
+        childBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(childBudget);
         helper.UserDataContext.SaveChanges();
@@ -873,21 +889,21 @@ public class BudgetServiceTests
         var parentBudget = budgetFaker.Generate();
         parentBudget.Category = "Income";
         parentBudget.Limit = 1500;
-        parentBudget.Date = DateTime.Today;
+        parentBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(parentBudget);
 
         var childBudget1 = budgetFaker.Generate();
         childBudget1.Category = "Paycheck";
         childBudget1.Limit = 1000;
-        childBudget1.Date = DateTime.Today;
+        childBudget1.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(childBudget1);
 
         var childBudget2 = budgetFaker.Generate();
         childBudget2.Category = "Bonus";
         childBudget2.Limit = 500;
-        childBudget2.Date = DateTime.Today;
+        childBudget2.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(childBudget2);
         helper.UserDataContext.SaveChanges();
@@ -1005,20 +1021,20 @@ public class BudgetServiceTests
         var parentBudget = budgetFaker.Generate();
         parentBudget.Category = "Income";
         parentBudget.Limit = 1000;
-        parentBudget.Date = DateTime.Today;
+        parentBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(parentBudget);
         var childBudget = budgetFaker.Generate();
         childBudget.Category = "Paycheck";
         childBudget.Limit = 200;
-        childBudget.Date = DateTime.Today;
+        childBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(childBudget);
 
         var childBudget2 = budgetFaker.Generate();
         childBudget2.Category = "Paycheck";
         childBudget2.Limit = 200;
-        childBudget2.Date = DateTime.Today.AddMonths(-1);
+        childBudget2.Month = DateOnly.FromDateTime(DateTime.Today.AddMonths(-1));
 
         helper.UserDataContext.Budgets.Add(childBudget2);
         helper.UserDataContext.SaveChanges();
@@ -1046,21 +1062,21 @@ public class BudgetServiceTests
         var parentBudget = budgetFaker.Generate();
         parentBudget.Category = "Income";
         parentBudget.Limit = 1500;
-        parentBudget.Date = DateTime.Today;
+        parentBudget.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(parentBudget);
 
         var childBudget1 = budgetFaker.Generate();
         childBudget1.Category = "Paycheck";
         childBudget1.Limit = 1000;
-        childBudget1.Date = DateTime.Today;
+        childBudget1.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(childBudget1);
 
         var childBudget2 = budgetFaker.Generate();
         childBudget2.Category = "Bonus";
         childBudget2.Limit = 500;
-        childBudget2.Date = DateTime.Today;
+        childBudget2.Month = DateOnly.FromDateTime(DateTime.Today);
 
         helper.UserDataContext.Budgets.Add(childBudget2);
         helper.UserDataContext.SaveChanges();

--- a/server/BudgetBoard.Tests/Fakers/BudgetFaker.cs
+++ b/server/BudgetBoard.Tests/Fakers/BudgetFaker.cs
@@ -8,7 +8,14 @@ class BudgetFaker : Faker<Budget>
     public BudgetFaker(Guid userID)
     {
         RuleFor(b => b.ID, f => Guid.NewGuid())
-            .RuleFor(b => b.Date, f => f.Date.Between(DateTime.Now.AddMonths(-2), DateTime.Now))
+            .RuleFor(
+                b => b.Month,
+                f =>
+                {
+                    var randomDate = f.Date.Between(DateTime.Now.AddMonths(-2), DateTime.Now);
+                    return new DateOnly(randomDate.Year, randomDate.Month, 1);
+                }
+            )
             .RuleFor(b => b.Category, f => f.Finance.AccountName())
             .RuleFor(b => b.Limit, f => f.Finance.Amount())
             .RuleFor(b => b.UserID, f => userID);

--- a/server/BudgetBoard.WebAPI/Controllers/BudgetController.cs
+++ b/server/BudgetBoard.WebAPI/Controllers/BudgetController.cs
@@ -65,7 +65,7 @@ public class BudgetController(
 
     [HttpGet]
     [Authorize]
-    public async Task<IActionResult> Read(DateTime date)
+    public async Task<IActionResult> Read(DateOnly date)
     {
         try
         {

--- a/server/BudgetBoard.WebAPI/Controllers/BudgetController.cs
+++ b/server/BudgetBoard.WebAPI/Controllers/BudgetController.cs
@@ -65,14 +65,14 @@ public class BudgetController(
 
     [HttpGet]
     [Authorize]
-    public async Task<IActionResult> Read(DateOnly date)
+    public async Task<IActionResult> Read(DateOnly month)
     {
         try
         {
             return Ok(
                 await _budgetService.ReadBudgetsAsync(
                     new Guid(_userManager.GetUserId(User) ?? string.Empty),
-                    date
+                    month
                 )
             );
         }


### PR DESCRIPTION
Budgets were missed when we converted some values to store dateonly instead of datetime. The timezone was causing issues.