### PR TITLE
Include hide from budgets when default disabled

### DIFF
--- a/server/BudgetBoard.Service/BudgetService.cs
+++ b/server/BudgetBoard.Service/BudgetService.cs
@@ -235,13 +235,7 @@ public class BudgetService(
             tc => new TransactionCategoryBase { Value = tc.Value, Parent = tc.Parent }
         );
 
-        var allCategories =
-            userData.UserSettings?.DisableBuiltInTransactionCategories == true
-                ? customCategories
-                : TransactionCategoriesConstants.DefaultTransactionCategories.Concat(
-                    customCategories
-                );
-
+        var allCategories = TransactionCategoriesHelpers.GetAllTransactionCategories(userData);
         if (TransactionCategoriesHelpers.GetIsParentCategory(budget.Category, allCategories))
         {
             var childBudgetsForMonth = GetChildBudgetsForMonth(

--- a/server/BudgetBoard.Service/BudgetService.cs
+++ b/server/BudgetBoard.Service/BudgetService.cs
@@ -153,7 +153,6 @@ public class BudgetService(
         budget.Limit = request.Limit;
 
         var allCategories = TransactionCategoriesHelpers.GetAllTransactionCategories(userData);
-
         if (TransactionCategoriesHelpers.GetIsParentCategory(budget.Category, allCategories))
         {
             var childBudgetsLimitTotal = GetBudgetChildrenLimit(
@@ -231,10 +230,6 @@ public class BudgetService(
 
         _userDataContext.Budgets.Remove(budget);
 
-        var customCategories = userData.TransactionCategories.Select(
-            tc => new TransactionCategoryBase { Value = tc.Value, Parent = tc.Parent }
-        );
-
         var allCategories = TransactionCategoriesHelpers.GetAllTransactionCategories(userData);
         if (TransactionCategoriesHelpers.GetIsParentCategory(budget.Category, allCategories))
         {
@@ -260,7 +255,6 @@ public class BudgetService(
     )
     {
         var allCategories = TransactionCategoriesHelpers.GetAllTransactionCategories(userData);
-
         var childBudgets = userData.Budgets.Where(b =>
             !TransactionCategoriesHelpers.GetIsParentCategory(b.Category, allCategories)
             && TransactionCategoriesHelpers

--- a/server/BudgetBoard.Service/Helpers/TransactionCategoriesHelpers.cs
+++ b/server/BudgetBoard.Service/Helpers/TransactionCategoriesHelpers.cs
@@ -111,6 +111,13 @@ internal static class TransactionCategoriesHelpers
             userData.TransactionCategories.Select(tc => new CategoryResponse(tc)).ToList()
         );
 
+        // Special categories are always included, regardless of user settings.
+        allTransactionCategories.AddRange(
+            TransactionCategoriesConstants
+                .SpecialTransactionCategories.Select(tc => new CategoryResponse(tc))
+                .ToList()
+        );
+
         if (userData.UserSettings?.DisableBuiltInTransactionCategories != true)
         {
             allTransactionCategories.AddRange(

--- a/server/BudgetBoard.Service/Models/TransactionCategoriesConstants.cs
+++ b/server/BudgetBoard.Service/Models/TransactionCategoriesConstants.cs
@@ -2,7 +2,7 @@
 
 public static class TransactionCategoriesConstants
 {
-    public static readonly IEnumerable<ITransactionCategory> SpecialTransactionCategories =
+    public static readonly IReadOnlyCollection<ITransactionCategory> SpecialTransactionCategories =
         new List<ITransactionCategory>(
             [
                 new TransactionCategoryBase
@@ -13,7 +13,7 @@ public static class TransactionCategoriesConstants
                 },
             ]
         );
-    public static readonly IEnumerable<ITransactionCategory> DefaultTransactionCategories =
+    public static readonly IReadOnlyCollection<ITransactionCategory> DefaultTransactionCategories =
         new List<ITransactionCategory>(
             [
                 new TransactionCategoryBase

--- a/server/BudgetBoard.Service/Models/TransactionCategoriesConstants.cs
+++ b/server/BudgetBoard.Service/Models/TransactionCategoriesConstants.cs
@@ -2,6 +2,17 @@
 
 public static class TransactionCategoriesConstants
 {
+    public static readonly IEnumerable<ITransactionCategory> SpecialTransactionCategories =
+        new List<ITransactionCategory>(
+            [
+                new TransactionCategoryBase
+                {
+                    Value = "Hide from Budgets",
+                    Parent = "",
+                    CategoryType = TransactionCategoryTypes.Expense,
+                },
+            ]
+        );
     public static readonly IEnumerable<ITransactionCategory> DefaultTransactionCategories =
         new List<ITransactionCategory>(
             [
@@ -315,12 +326,6 @@ public static class TransactionCategoriesConstants
                 {
                     Value = "Sports",
                     Parent = "Health & Fitness",
-                    CategoryType = TransactionCategoryTypes.Expense,
-                },
-                new TransactionCategoryBase
-                {
-                    Value = "Hide from Budgets",
-                    Parent = "",
                     CategoryType = TransactionCategoryTypes.Expense,
                 },
                 new TransactionCategoryBase

--- a/server/BudgetBoard.Tests/BudgetServiceTests.cs
+++ b/server/BudgetBoard.Tests/BudgetServiceTests.cs
@@ -130,13 +130,13 @@ public class BudgetServiceTests
             TestHelper.CreateMockLocalizer<LogStrings>()
         );
 
-        var budgets = _budgetCreateRequestFaker.Generate(5);
+        var budgets = _budgetCreateRequestFaker.Generate(2);
 
         // Act
         await budgetService.CreateBudgetsAsync(helper.demoUser.Id, budgets);
 
         // Assert
-        helper.UserDataContext.Budgets.Should().HaveCount(5);
+        helper.UserDataContext.Budgets.Should().HaveCount(2);
     }
 
     [Fact]

--- a/server/BudgetBoard.Tests/TransactionCategoryServiceTests.cs
+++ b/server/BudgetBoard.Tests/TransactionCategoryServiceTests.cs
@@ -271,7 +271,7 @@ public class TransactionCategoryServiceTests
     }
 
     [Fact]
-    public async Task ReadTransactionCategoriesAsync_WhenCalledWithValidData_ShouldReturnCustomAndDefaultCategories()
+    public async Task ReadTransactionCategoriesAsync_WhenCalledWithValidData_ShouldReturnCustomSpecialAndDefaultCategories()
     {
         // Arrange
         var helper = new TestHelper();
@@ -296,17 +296,23 @@ public class TransactionCategoryServiceTests
 
         // Assert
         var expectedCustomCategories = transactionCategories.Select(t => new CategoryResponse(t));
+        var expectedSpecialCategories =
+            TransactionCategoriesConstants.SpecialTransactionCategories.Select(
+                tc => new CategoryResponse(tc)
+            );
         var expectedDefaultCategories =
             TransactionCategoriesConstants.DefaultTransactionCategories.Select(
                 tc => new CategoryResponse(tc)
             );
-        var expectedAll = expectedCustomCategories.Concat(expectedDefaultCategories);
+        var expectedAll = expectedCustomCategories
+            .Concat(expectedSpecialCategories)
+            .Concat(expectedDefaultCategories);
 
         result.Should().BeEquivalentTo(expectedAll);
     }
 
     [Fact]
-    public async Task ReadTransactionCategoriesAsync_WhenDefaultsDisabled_ShouldReturnOnlyCustomCategories()
+    public async Task ReadTransactionCategoriesAsync_WhenDefaultsDisabled_ShouldReturnSpecialAndCustomCategories()
     {
         // Arrange
         var helper = new TestHelper();
@@ -340,7 +346,13 @@ public class TransactionCategoryServiceTests
 
         // Assert
         var expectedCustomCategories = transactionCategories.Select(t => new CategoryResponse(t));
-        result.Should().BeEquivalentTo(expectedCustomCategories);
+        var expectedSpecialCategories =
+            TransactionCategoriesConstants.SpecialTransactionCategories.Select(
+                tc => new CategoryResponse(tc)
+            );
+        var expectedAll = expectedCustomCategories.Concat(expectedSpecialCategories);
+
+        result.Should().BeEquivalentTo(expectedAll);
         result
             .Should()
             .NotContainEquivalentOf(


### PR DESCRIPTION
Hide from budgets is a special category that isn't really a category, so it _shouldn't_ be hidden even when default categories are hidden.

I've created a new set of special categories that are always included.