### PR TITLE
Remove conditional service creation for oidc

### DIFF
--- a/server/BudgetBoard.WebAPI/Controllers/ApplicationUserController.cs
+++ b/server/BudgetBoard.WebAPI/Controllers/ApplicationUserController.cs
@@ -67,6 +67,7 @@ public class ApplicationUserController(
     [HttpDelete]
     [Route("[action]")]
     [Authorize]
+    [RequireOidcEnabled]
     public async Task<IActionResult> DisconnectOidcLogin()
     {
         return await HandleRequestAsync(async () =>
@@ -86,6 +87,7 @@ public class ApplicationUserController(
     [HttpPost]
     [Route("[action]")]
     [Authorize]
+    [RequireOidcEnabled]
     public async Task<IActionResult> ConnectOidcLogin([FromBody] OidcCallbackRequest request)
     {
         return await HandleRequestAsync(async () =>

--- a/server/BudgetBoard.WebAPI/Program.cs
+++ b/server/BudgetBoard.WebAPI/Program.cs
@@ -185,11 +185,9 @@ var autoUpdateDb = builder.Configuration.GetValue<bool>("AUTO_UPDATE_DB");
 // Register the new provisioning service after Identity is configured
 builder.Services.AddScoped<IExternalUserProvisioningService, ExternalUserProvisioningService>();
 
-// Register OIDC token service if OIDC is enabled
-if (oidcEnabled)
-{
-    builder.Services.AddScoped<IOidcTokenService, OidcTokenService>();
-}
+// ApplicationUserController depends on this service even when OIDC is disabled.
+// OIDC settings are validated before the service exchanges a code.
+builder.Services.AddScoped<IOidcTokenService, OidcTokenService>();
 
 if (!builder.Configuration.GetValue<bool>("DISABLE_AUTO_SYNC"))
 {


### PR DESCRIPTION
As part of the OIDC changes in #955 we added a dependency of the OIDC service in the application user. This causes things to break when OIDC is disabled. We should removed the scoped creation to always create the service, since we have other means to gate OIDC access when it is disabled.